### PR TITLE
docs(docker): document the all-in-one self-host image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -27,7 +27,7 @@ The `/data` volume holds MongoDB, scenario uploads, and the backend's SQLite sta
 
 **Security note**: this image disables OAuth and serves every request as an anonymous "Local User". It's meant for local self-host. Do not expose port 8080 to the public internet.
 
-**Licensing note**: the all-in-one image bundles MongoDB Community (SSPL v1). Running it as a self-host install is permitted; offering it as a hosted service for third parties would trigger the SSPL's service-provider clauses.
+**Licensing note**: the all-in-one image bundles MongoDB Community, which is distributed under the Server Side Public License (SSPL) v1. See the license text at https://www.mongodb.com/licensing/server-side-public-license and review its requirements for your intended use and deployment model.
 
 ## Multi-container — separate frontend, backends, and MongoDB
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,7 @@ Stop cleanly (mongod needs ~60 s on a busy DB):
 docker stop --time 60 jupedsim
 ```
 
-The `/data` volume holds MongoDB, scenario uploads, and the backend's sqlite state, so your scenarios survive `docker restart` and `docker rm`. Allow ~60 s on first start.
+The `/data` volume holds MongoDB, scenario uploads, and the backend's SQLite state, so your scenarios survive `docker restart` and `docker rm`. Allow ~60 s on first start.
 
 **Security note**: this image disables OAuth and serves every request as an anonymous "Local User". It's meant for local self-host. Do not expose port 8080 to the public internet.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,13 +1,44 @@
 # Run JuPedSim Web Locally (Docker)
 
-This folder provides a ready-to-run local deployment using prebuilt Docker images from Docker Hub.
+Two ways to run the simulator on your own machine, depending on how much control you want.
 
-## Prerequisites
+## Quick start — one container (self-host)
+
+The fastest path. Bundles the frontend, both backends, and MongoDB into a single image. No clone, no compose file, no `.env`, no OAuth setup.
+
+```bash
+docker run -d \
+  --name jupedsim \
+  -p 8080:8080 \
+  -v jupedsim-data:/data \
+  --memory 4g \
+  jupedsim/jupedsim-web:latest
+```
+
+Open: http://localhost:8080
+
+Stop cleanly (mongod needs ~60 s on a busy DB):
+
+```bash
+docker stop --time 60 jupedsim
+```
+
+The `/data` volume holds MongoDB, scenario uploads, and the backend's sqlite state, so your scenarios survive `docker restart` and `docker rm`. Allow ~60 s on first start.
+
+**Security note**: this image disables OAuth and serves every request as an anonymous "Local User". It's meant for local self-host. Do not expose port 8080 to the public internet.
+
+**Licensing note**: the all-in-one image bundles MongoDB Community (SSPL v1). Running it as a self-host install is permitted; offering it as a hosted service for third parties would trigger the SSPL's service-provider clauses.
+
+## Multi-container — separate frontend, backends, and MongoDB
+
+Use this when you want per-service updates, an external MongoDB, or to front the stack with OAuth.
+
+### Prerequisites
 
 - Docker Desktop (or Docker Engine + Compose plugin)
 - Access to image namespace: `jupedsim/*`
 
-## Start
+### Start
 
 ```bash
 cd docker
@@ -18,13 +49,13 @@ docker compose --env-file .env -f docker-compose.yml up -d
 
 Open: http://localhost:8080
 
-## Stop
+### Stop
 
 ```bash
 docker compose --env-file .env -f docker-compose.yml down
 ```
 
-## Update to a Specific Image Tag
+### Update to a Specific Image Tag
 
 Set `IMAGE_TAG` in `docker/.env`, then pull and restart:
 
@@ -37,3 +68,4 @@ docker compose --env-file .env -f docker-compose.yml up -d
 
 - If image pulls fail with `manifest unknown`, verify `IMAGE_TAG` exists.
 - If pushes/pulls fail with auth errors, run `docker login`.
+- If the frontend container crashes with `host not found in upstream` on a version earlier than v1.6, upgrade to v1.6 or later — the upstream hostnames were aligned with the compose service names.


### PR DESCRIPTION
## Why

Web-Based-Jupedsim v1.6 publishes a fourth image, \`jupedsim/jupedsim-web\`, that bundles the frontend, both backends, and MongoDB into a single linux/amd64 container with anonymous local-user auth. The floor for trying the simulator drops to one command:

\`\`\`bash
docker run -d -p 8080:8080 -v jupedsim-data:/data jupedsim/jupedsim-web:latest
\`\`\`

This README still leads with the multi-container compose flow, which has more moving parts than most first-time users want.

## What

- Lead with **Quick start — one container (self-host)** using the new image. Cover the security and SSPL notes from the upstream README so the licensing posture is explicit.
- Keep the multi-container compose flow as the **second section** for users who want per-service updates, an external MongoDB, or OAuth in front.
- Add a troubleshooting line pointing pre-v1.6 users at the nginx upstream-hostname fix that shipped in v1.6 (PedestrianDynamics/Web-Based-Jupedsim#380).

## Related

- Upstream feature PR: PedestrianDynamics/Web-Based-Jupedsim#381
- Upstream changelog entry: \`CHANGELOG.md\` v1.6 (2026-05-12)