### PR TITLE
chore: bump jupedsim-scenarios to 0.3.3 and drop xfail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "ipykernel",
     "jupyter",
     "jupedsim",
-    "jupedsim-scenarios>=0.3.2",
+    "jupedsim-scenarios>=0.3.3",
     "numpy",
     "pandas",
     "pedpy",

--- a/scripts/test_shared_examples.py
+++ b/scripts/test_shared_examples.py
@@ -1,8 +1,6 @@
 import copy
 from pathlib import Path
 
-import pytest
-
 from jupedsim_scenarios import Scenario, load_scenario, run_scenario
 
 
@@ -47,16 +45,6 @@ def test_bottleneck_zone_slows_down_agents():
         zone_result.cleanup()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "jupedsim-scenarios v0.3.2 bypasses waiting-stage checkpoints when no "
-        "journeys_v2 is defined — the nearest-exit fallback fires and skips the "
-        "checkpoint entirely. Tracked at "
-        "https://github.com/PedestrianDynamics/jupedsim-scenarios/issues/8 ; "
-        "drop this mark once the bug is fixed and the pin is bumped."
-    ),
-    strict=True,
-)
 def test_waiting_stage_holds_agents_before_exit():
     scenario = load_scenario(str(SCENARIOS_DIR / "waiting-stage-corridor"))
     baseline_raw = copy.deepcopy(scenario.raw)

--- a/uv.lock
+++ b/uv.lock
@@ -889,7 +889,7 @@ wheels = [
 
 [[package]]
 name = "jupedsim-scenarios"
-version = "0.3.2"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
@@ -899,9 +899,9 @@ dependencies = [
     { name = "pedpy" },
     { name = "shapely" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/5d/2fcffe4c74890766f876a1d3279e6d7c467e0acce4d4021c6bc1796a078b/jupedsim_scenarios-0.3.2.tar.gz", hash = "sha256:84d751bcf9ae8563608c4b79d63cfefffb8d7c510c6812d8b1e4f7809a714454", size = 47397, upload-time = "2026-05-21T20:39:45.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/4c/6ce65064c95cc4e0e41519b08652352ea0176eda853253eb283d14d97746/jupedsim_scenarios-0.3.3.tar.gz", hash = "sha256:a58114863ae008be3c7a75417dccf37899197d0760e723f4a0b7a88b7a9e9ddd", size = 48462, upload-time = "2026-05-21T21:20:10.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/81/2a270c73b6a15b01e75cb9b615f6f737053fefbf1bfe01bb7f2d61a89193/jupedsim_scenarios-0.3.2-py3-none-any.whl", hash = "sha256:103b438b29fbaab5a782e13c97fc21666dce422a18c3262653703fa191f4d9c0", size = 45302, upload-time = "2026-05-21T20:39:43.637Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/f316d8f58ccfbf831a3250f682cd65d4668ec635c7d90458d24718028dc5/jupedsim_scenarios-0.3.3-py3-none-any.whl", hash = "sha256:4d58349952b60efefd03a91afd12db462776921141b21af1a33075db913ca3a2", size = 46043, upload-time = "2026-05-21T21:20:08.726Z" },
 ]
 
 [[package]]
@@ -928,7 +928,7 @@ dev = [
 requires-dist = [
     { name = "ipykernel" },
     { name = "jupedsim" },
-    { name = "jupedsim-scenarios", specifier = ">=0.3.2" },
+    { name = "jupedsim-scenarios", specifier = ">=0.3.3" },
     { name = "jupyter" },
     { name = "numpy" },
     { name = "pandas" },


### PR DESCRIPTION
## Summary

[jupedsim-scenarios#8](https://github.com/PedestrianDynamics/jupedsim-scenarios/issues/8) is fixed in v0.3.3 (just published). Bump the pin and remove the `xfail(strict=True)` mark on `test_waiting_stage_holds_agents_before_exit` that was tracking the regression.

### Files

- `pyproject.toml` — `jupedsim-scenarios>=0.3.2` → `>=0.3.3`.
- `scripts/test_shared_examples.py` — drop the xfail decorator and the now-unused `pytest` import.
- `uv.lock` — `uv lock --refresh` picks up the new version.

## Test plan

- [x] `uv lock --refresh` resolves `jupedsim-scenarios v0.3.3`.
- [x] Verified manually before tagging v0.3.3: the test that was XFAIL'd flips to XPASS(strict) under the fix; removing the mark restores it to a normal PASS. (Couldn't re-confirm in a fresh venv locally because of an unrelated numpy 2.4.6 install bug on macOS; CI on Ubuntu will validate.)
- [ ] CI green on this PR (the bot you trust most).

This closes the loop: the community repo and the web app are both pinned to `jupedsim-scenarios==0.3.3` and run identical scenario code.
