### PR TITLE
feat: drive scenario_api_demo + stage_routing + template_script with run_sweep

### DIFF
--- a/scripts/scenario_api_demo.ipynb
+++ b/scripts/scenario_api_demo.ipynb
@@ -245,7 +245,7 @@
     "\n",
     "RiMEA 10 has 12 rooms feeding into 2 exits. We scale agent counts uniformly across all distributions and measure evacuation time over multiple seeds.\n",
     "\n",
-    "The sweep loop is concise thanks to `copy()` and index aliases \u2014 no string-key bookkeeping."
+    "The sweep is driven by `jupedsim_scenarios.run_sweep`, which owns per-trial `.copy()`/cleanup, the cartesian product over the agent-count axis and seed values, and parallel dispatch via the loky backend. The mutator below uses index aliases (`set_agent_count(i, n)`) instead of string-key bookkeeping."
    ]
   },
   {

--- a/scripts/scenario_api_demo.ipynb
+++ b/scripts/scenario_api_demo.ipynb
@@ -19,12 +19,12 @@
     "| Input validation | Silent corruption | `ValueError` on bad input |\n",
     "| Zones / checkpoints | Edit `raw` dict by hand | `set_zone_speed_factor()`, `set_checkpoint_waiting_time()` |\n",
     "\n",
-    "**Scenario:** RiMEA 10 — 12 rooms, 2 exits, pre-assigned routes. We sweep agent counts to see how crowd size affects evacuation time."
+    "**Scenario:** RiMEA 10 \u2014 12 rooms, 2 exits, pre-assigned routes. We sweep agent counts to see how crowd size affects evacuation time."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "80225xacblu",
    "metadata": {},
    "outputs": [],
@@ -32,7 +32,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from jupedsim_scenarios import load_scenario, run_scenario\n",
+    "from jupedsim_scenarios import load_scenario, run_sweep\n",
     "\n",
     "plt.rcParams.update({\n",
     "    \"figure.facecolor\": \"white\",\n",
@@ -51,7 +51,7 @@
    "source": [
     "## 1. Load and Discover\n",
     "\n",
-    "`list_distributions()` returns a clean summary — no need to dig through nested dicts."
+    "`list_distributions()` returns a clean summary \u2014 no need to dig through nested dicts."
    ]
   },
   {
@@ -120,7 +120,7 @@
    "id": "ykzmgzyi5z",
    "metadata": {},
    "source": [
-    "`scenario.plot()` renders the walkable area with labeled distributions, exits, zones, and checkpoints — one call to understand what you're working with."
+    "`scenario.plot()` renders the walkable area with labeled distributions, exits, zones, and checkpoints \u2014 one call to understand what you're working with."
    ]
   },
   {
@@ -194,7 +194,7 @@
     "]:\n",
     "    try:\n",
     "        fn()\n",
-    "        print(f\"  {label}: ERROR — should have raised!\")\n",
+    "        print(f\"  {label}: ERROR \u2014 should have raised!\")\n",
     "    except ValueError:\n",
     "        print(f\"  {label}: caught ValueError\")"
    ]
@@ -245,37 +245,51 @@
     "\n",
     "RiMEA 10 has 12 rooms feeding into 2 exits. We scale agent counts uniformly across all distributions and measure evacuation time over multiple seeds.\n",
     "\n",
-    "The sweep loop is concise thanks to `copy()` and index aliases — no string-key bookkeeping."
+    "The sweep loop is concise thanks to `copy()` and index aliases \u2014 no string-key bookkeeping."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "8z7reiem9gs",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%capture\n",
+    "# Sweep agents-per-room \u00d7 seed via run_sweep \u2014 the library applies the\n",
+    "# per-distribution agent-count mutator to a fresh .copy() of the base\n",
+    "# for every trial and runs them in parallel (workers=4).\n",
     "agents_per_room = [1, 3, 5, 8]\n",
     "seeds = [42, 43, 44]\n",
     "n_distributions = len(base.list_distributions())\n",
     "\n",
-    "results = {}\n",
-    "for n in agents_per_room:\n",
-    "    scenario = base.copy()\n",
-    "    scenario.set_max_time(500)\n",
+    "base_with_time = base.copy()\n",
+    "base_with_time.set_max_time(500)\n",
+    "\n",
+    "\n",
+    "def _set_count_for_all_distributions(scenario, n):\n",
     "    for i in range(n_distributions):\n",
     "        scenario.set_agent_count(i, n)\n",
     "\n",
-    "    evac_times = []\n",
-    "    for seed in seeds:\n",
-    "        result = run_scenario(scenario, seed=seed)\n",
-    "        evac_times.append(result.evacuation_time)\n",
-    "        result.cleanup()\n",
     "\n",
+    "sweep = run_sweep(\n",
+    "    base_with_time,\n",
+    "    axes={\"n\": agents_per_room},\n",
+    "    apply={\"n\": _set_count_for_all_distributions},\n",
+    "    seeds=seeds,\n",
+    "    workers=4,\n",
+    ")\n",
+    "df = sweep.to_dataframe()\n",
+    "sweep.cleanup()\n",
+    "\n",
+    "# Reproduce the same `results = {total_agents: [evac_times]}` shape so\n",
+    "# downstream cells don't need to change.\n",
+    "results = {}\n",
+    "for n in agents_per_room:\n",
+    "    evac_times = df.loc[df[\"n\"] == n, \"evacuation_time\"].to_numpy()\n",
     "    total = n * n_distributions\n",
-    "    results[total] = np.array(evac_times)\n",
-    "    print(f\"{total:3d} agents -> {np.mean(evac_times):.1f}s (seeds: {evac_times})\")"
+    "    results[total] = evac_times\n",
+    "    print(f\"{total:3d} agents -> {evac_times.mean():.1f}s (seeds: {list(evac_times)})\")"
    ]
   },
   {

--- a/scripts/stage_routing_square_room.ipynb
+++ b/scripts/stage_routing_square_room.ipynb
@@ -30,7 +30,7 @@
     "import numpy as np\n",
     "import pedpy\n",
     "\n",
-    "from jupedsim_scenarios import load_scenario, run_scenario\n"
+    "from jupedsim_scenarios import load_scenario, run_scenario, run_sweep"
    ]
   },
   {
@@ -170,17 +170,15 @@
     "    demo_metrics = dict(demo_result.metrics)\n",
     "    demo_result.cleanup()\n",
     "\n",
-    "    evac_times = []\n",
-    "    for seed in seeds:\n",
-    "        result = run_scenario(scenario, seed=seed)\n",
-    "        evac_times.append(result.evacuation_time)\n",
-    "        result.cleanup()\n",
+    "    sweep = run_sweep(scenario, seeds=list(seeds), workers=4)\n",
+    "    evac_times = sweep.to_dataframe()[\"evacuation_time\"].to_numpy()\n",
+    "    sweep.cleanup()\n",
     "\n",
     "    return {\n",
     "        \"demo_seed\": demo_seed,\n",
     "        \"demo_traj\": demo_traj,\n",
     "        \"demo_metrics\": demo_metrics,\n",
-    "        \"evac_times\": np.asarray(evac_times, dtype=float),\n",
+    "        \"evac_times\": evac_times.astype(float),\n",
     "    }\n",
     "\n",
     "\n",

--- a/scripts/template_script.ipynb
+++ b/scripts/template_script.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jupedsim_scenarios import load_scenario, run_sweep"
+    "from jupedsim_scenarios import load_scenario, run_scenario, run_sweep"
    ]
   },
   {

--- a/scripts/template_script.ipynb
+++ b/scripts/template_script.ipynb
@@ -22,7 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jupedsim_scenarios import load_scenario, run_scenario"
+    "from jupedsim_scenarios import load_scenario, run_sweep"
    ]
   },
   {
@@ -149,14 +149,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Seed-only sweep \u2014 run_sweep handles per-trial .copy()/.cleanup()\n",
+    "# bookkeeping and dispatches the trials in parallel.\n",
     "seeds = [1, 2, 3, 4, 5]\n",
-    "evac_times = []\n",
+    "sweep = run_sweep(scenario, seeds=seeds, workers=4)\n",
+    "evac_times = sweep.to_dataframe()[\"evacuation_time\"].tolist()\n",
+    "sweep.cleanup()\n",
     "\n",
-    "for s in seeds:\n",
-    "    r = run_scenario(scenario, seed=s)\n",
-    "    evac_times.append(r.evacuation_time)\n",
-    "    r.cleanup()\n",
-    "    print(f\"  Seed {s}: {r.evacuation_time:.2f}s\")\n",
+    "for s, t in zip(seeds, evac_times):\n",
+    "    print(f\"  Seed {s}: {t:.2f}s\")\n",
     "\n",
     "print(f\"\\nMean: {sum(evac_times)/len(evac_times):.2f}s, \"\n",
     "      f\"Min: {min(evac_times):.2f}s, Max: {max(evac_times):.2f}s\")"
@@ -181,17 +182,23 @@
     "\n",
     "base_scenario = load_scenario(\"scenarios/jps_2026_03_07_10_54_07.zip\")\n",
     "counts = [5, 10, 20, 30]\n",
-    "results_by_count = {}\n",
     "\n",
-    "for n in counts:\n",
-    "    scenario_variant = base_scenario.copy()\n",
-    "    scenario_variant.set_agent_count(0, n)\n",
-    "    r = run_scenario(scenario_variant)\n",
-    "    results_by_count[n] = r.evacuation_time\n",
-    "    r.cleanup()\n",
-    "    print(f\"{n} agents: {r.evacuation_time:.2f}s\")\n",
+    "# Sweep the agent-count axis via run_sweep \u2014 parallel trials, no\n",
+    "# manual .copy() / .cleanup() bookkeeping.\n",
+    "sweep = run_sweep(\n",
+    "    base_scenario,\n",
+    "    axes={\"n\": counts},\n",
+    "    apply={\"n\": lambda s, v: s.set_agent_count(0, v)},\n",
+    "    workers=4,\n",
+    ")\n",
+    "df = sweep.to_dataframe()\n",
+    "sweep.cleanup()\n",
     "\n",
-    "times = [results_by_count[n] for n in counts]\n"
+    "results_by_count = dict(zip(df[\"n\"], df[\"evacuation_time\"]))\n",
+    "for n, t in results_by_count.items():\n",
+    "    print(f\"{n} agents: {t:.2f}s\")\n",
+    "\n",
+    "times = [results_by_count[n] for n in counts]"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Third batch of `run_sweep` conversions in the community repo, following #111 and #112. Three notebooks, four loops.

### `scenario_api_demo.ipynb`

Cell 11's nested `for n in agents_per_room: for seed in seeds:` becomes one `run_sweep(axes={"n": agents_per_room}, seeds=seeds, workers=4)`. 4×3 = 12 trials run in parallel. The `results = {total_agents: evac_times}` dict downstream cells use is rebuilt from the dataframe to preserve the public shape.

### `stage_routing_square_room.ipynb`

Inside `run_variant`, the per-variant 15-seed sweep becomes `run_sweep(scenario, seeds=list(seeds), workers=4)`. The single pinned-seed demo run that feeds the trajectory plot stays as `run_scenario`. The outer `for name, scenario in SCENARIOS:` loop stays as-is — different scenarios, not axes of one base.

### `template_script.ipynb`

Two loops:
- **Cell 13** — pure 5-seed sweep → `run_sweep(scenario, seeds=...)`.
- **Cell 15** — 4-value agent-count sweep → `run_sweep(base, axes={"n": counts}, apply={"n": set_agent_count})`.

Both parallelised (`workers=4`). `results_by_count` rebuilt from the dataframe.

## Skipped intentionally

Same shape as the rimea16 case filed at [jupedsim-scenarios#11](https://github.com/PedestrianDynamics/jupedsim-scenarios/issues/11) — factory-style scenario construction that rebuilds geometry per iteration:

- `rimea12b_bottleneck_length.ipynb` — `make_geometry(length)` + `make_exit(length)` rebuild the scenario per length.
- `rimea07_demographic_params.ipynb` — uses `build_raw_scenario` factory.
- `rimea13_fd_stairs.ipynb` — uses `build_raw_scenario(direction=...)` factory.

These stay on their factory loops until #11 introduces a `run_sweep_from_factory` (or equivalent) pattern.

## Roll-up

After this lands, **6 of 14** parameter-study notebooks use `run_sweep` (`faster_is_slower`, `model_comparison`, `bottleneck_zone_nt_diagram`, `scenario_api_demo`, `stage_routing_square_room`, `template_script`). Three more are gated on #11. The rest don't sweep at all.

## Test plan

- [x] All edited code cells parse (`ast.parse`).
- [x] No `for seed in seeds: run_scenario` residue in any of the three.
- [x] Downstream variable names preserved (`results`, `results_by_count`, `evac_times`) so plotting/analysis cells don't need to change.
- [ ] CI on this PR.
