### PR TITLE
ci: run V&V workflows on pull_request too

### DIFF
--- a/.github/workflows/imo.yml
+++ b/.github/workflows/imo.yml
@@ -9,6 +9,14 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/imo.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "tests/vv/test_imo_*.py"
+      - "tests/vv/vv_helpers.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/imo.yml"
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch: {}

--- a/.github/workflows/rimea.yml
+++ b/.github/workflows/rimea.yml
@@ -9,6 +9,14 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/rimea.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "tests/vv/test_rimea.py"
+      - "tests/vv/vv_helpers.py"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/rimea.yml"
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch: {}

--- a/.github/workflows/vv.yml
+++ b/.github/workflows/vv.yml
@@ -3,6 +3,8 @@ name: V&V Tests
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: "0 6 * * 1"  # Weekly Monday 06:00 UTC
   workflow_dispatch: {}


### PR DESCRIPTION
Right now `vv.yml`, `imo.yml`, and `rimea.yml` only fire on push to main. Any breakage to the V&V test setup lands on main BEFORE CI can catch it — that's exactly how PR #115's broken-commit state shipped a red main with stale-green badges, and how PR #116 merged before the post-merge V&V failures were visible.

Add `pull_request:` triggers mirroring the existing push triggers (same path filters on imo/rimea). Future PRs touching the test files or workflows get pre-merge validation.

Originally bundled into PR #116; that PR merged before this commit got reviewed, so I'm shipping it standalone.