### PR TITLE
ci: skip 'Update pinned issue' step on pull_request runs

### DIFF
--- a/.github/workflows/vv.yml
+++ b/.github/workflows/vv.yml
@@ -115,7 +115,11 @@ jobs:
         "
 
     - name: Update pinned issue
-      if: always()
+      # Only push/schedule runs on main update the pinned tracking issue.
+      # PR builds (especially from forks) have reduced GITHUB_TOKEN scope
+      # and would either fail the PATCH or pollute the pinned issue with
+      # in-flight PR results.
+      if: always() && github.event_name != 'pull_request'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |


### PR DESCRIPTION
Follow-up to the Copilot review on PR #117 (since merged). The `pull_request:` trigger I added to vv.yml means the 'Update pinned issue' step now fires on PR builds too — but that step PATCHes pinned issue #67 with the run's V&V summary, which:

- overwrites the tracking-issue body meant to reflect main, with possibly-failing PR results
- fails outright on PRs from forks (`GITHUB_TOKEN` is read-only there)

Gate the step on `github.event_name != 'pull_request'` so only push and schedule runs (both fire only on main) touch the issue. PR validation still runs the V&V tests end-to-end; only the publish side-effect is restricted to main.

Caught by Copilot review on #117, addressed as a follow-up since #117 was already merged.