### PR TITLE
chore: repo cleanup pass — onboarding, CI hygiene, API drift safety

### DIFF
--- a/.github/workflows/imo.yml
+++ b/.github/workflows/imo.yml
@@ -28,6 +28,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
 
     - name: Sync environment
       run: uv sync --extra dev

--- a/.github/workflows/rimea.yml
+++ b/.github/workflows/rimea.yml
@@ -28,6 +28,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
 
     - name: Sync environment
       run: uv sync --extra dev

--- a/.github/workflows/scenario-examples.yml
+++ b/.github/workflows/scenario-examples.yml
@@ -3,21 +3,35 @@ name: Scenario Examples
 on:
   push:
     branches: [main]
+    paths:
+      - "standards/tests/**"
+      - "standards/general/scenario_files/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/scenario-examples.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "standards/tests/**"
+      - "standards/general/scenario_files/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/scenario-examples.yml"
   workflow_dispatch: {}
 
 jobs:
-  shared-scenario-examples:
+  scenario-examples:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
 
       - name: Sync environment
         run: uv sync --extra dev
 
-      - name: Run shared scenario examples
+      - name: Run webapp scenario examples
         working-directory: standards
         run: uv run --project .. pytest tests/test_webapp_scenarios.py -q

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,80 @@
+name: Upstream Drift
+
+# Detects API breakage in jupedsim-scenarios by upgrading it to the
+# latest release (bypassing uv.lock) and running the API surface test,
+# the V&V suite, and the scenario examples.
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  upstream-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Sync environment (latest jupedsim-scenarios)
+        run: |
+          uv sync --extra dev
+          uv pip install --upgrade jupedsim-scenarios jupedsim
+          uv pip list | grep -E "jupedsim"
+
+      - name: API surface smoke test
+        run: uv run --extra dev pytest tests/test_api_surface.py -v
+
+      - name: V&V tests
+        run: uv run --extra dev pytest tests/vv -q
+
+      - name: Webapp scenario examples
+        working-directory: standards
+        run: uv run --project .. pytest tests/test_webapp_scenarios.py -q
+
+      - name: Open issue on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'The upstream-drift workflow failed.',
+              '',
+              'This means the latest release of `jupedsim-scenarios` (or `jupedsim`)',
+              'is incompatible with this repository.',
+              '',
+              `**Run:** ${runUrl}`,
+              '',
+              'Next steps: inspect the failing job, then either pin around the',
+              'breakage or update this repo to the new API.',
+            ].join('\n');
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'upstream-drift',
+            });
+            if (issues.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Upstream drift: jupedsim-scenarios incompatible with latest release',
+                body,
+                labels: ['upstream-drift'],
+              });
+            }

--- a/.github/workflows/vv.yml
+++ b/.github/workflows/vv.yml
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
 
     - name: Sync environment
       run: uv sync --extra dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing
+
+This repository complements [JuPedSim Web](https://app.jupedsim.org). It
+hosts the public Docker setup, scenario-scripting workflow, V&V test
+suites, and example notebooks. The web app itself is private; this repo
+is community-facing.
+
+## Setup
+
+Dependencies are managed with [uv](https://docs.astral.sh/uv/). From the
+repository root:
+
+```bash
+uv sync --extra dev
+```
+
+This creates `.venv/` and installs runtime + test dependencies.
+
+## Running tests
+
+A single command from the repository root runs everything:
+
+```bash
+uv run --extra dev pytest
+```
+
+This collects:
+
+- `tests/vv/` — V&V suite (RiMEA, IMO).
+- `standards/tests/` — webapp scenario examples + scenario API tests.
+
+Run a subset:
+
+```bash
+uv run --extra dev pytest tests/vv/test_rimea.py        # RiMEA only
+uv run --extra dev pytest standards/tests                # standards only
+uv run --extra dev pytest tests/test_api_surface.py      # API surface smoke
+```
+
+Always run the relevant subset locally before pushing.
+
+## Repository layout
+
+- `standards/` — per-standard notebooks, scenario files, and tests.
+  - `general/`, `rimea/`, `imo/`, `iso/`, `nist/` — one folder per standard.
+  - Each standard owns `scenario_files/` (exported ZIPs from the webapp)
+    and any notebooks demonstrating the scenarios.
+  - `tests/` — pytest covering webapp scenarios + the scenario API.
+- `tests/vv/` — programmatic V&V suite (one test module per standard).
+- `docker/` — public local-deployment setup for the webapp.
+- `geometries/` — public geometry examples (DXF, IFC, WKT).
+- `.github/workflows/` — CI: per-standard test workflows, scenario
+  examples, scheduled notebook execution, and upstream-drift detection.
+
+## Adding a new standard
+
+1. Create `standards/<name>/scenario_files/` with the exported ZIPs.
+2. Add notebooks at `standards/<name>/*.ipynb`. Follow the layout of
+   `standards/rimea/`.
+3. Add a programmatic test module at `tests/vv/test_<name>.py` using
+   `vv_helpers.py`.
+4. Add a CI workflow at `.github/workflows/<name>.yml` mirroring
+   `rimea.yml` / `imo.yml`.
+5. Register the new tests in `tests/vv/test_registry.py` if applicable.
+
+## Scenarios
+
+All scenarios are authored in the JuPedSim web app and exported as ZIPs
+containing `config.json` and `geometry.wkt`. They are loaded with
+`jupedsim_scenarios.load_scenario(...)`. Do not hand-edit exported
+ZIPs; re-export from the webapp instead.
+
+## Notebooks
+
+Notebooks are committed **with outputs** so readers can see results
+without re-running heavy simulations. Trade-offs:
+
+- Re-running a notebook produces large diffs in cell outputs.
+- Each notebook has an "Executed on …" timestamp cell near the top.
+- The weekly `notebooks.yml` CI re-executes every notebook to catch
+  silent breakage; failures open a tracking issue.
+
+When reviewing notebook diffs, [`nbdime`](https://nbdime.readthedocs.io/)
+gives a readable cell-level view (install separately):
+
+```bash
+pipx install nbdime
+nbdiff --ignore-outputs path/to/notebook.ipynb
+```
+
+If you need to commit a notebook without re-running it, only edit
+markdown cells.
+
+## Upstream drift
+
+`jupedsim-scenarios` is the load-bearing dependency. Two safety nets:
+
+- `tests/test_api_surface.py` — fast smoke test of public symbols.
+- `.github/workflows/upstream-drift.yml` — weekly run against the
+  latest release; opens an issue on incompatibility.
+
+When bumping `jupedsim-scenarios`, run the API surface test first.
+
+## Git hygiene
+
+- Atomic commits with imperative subject lines.
+- Subject ≤ 70 chars, optional body explains the *why*.
+- No `--no-verify`. If a hook fails, fix it.
+- Prefer PRs for anything beyond chore-level fixes.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ With this repository you can:
 - Report issues and discuss feature ideas
 - Run the public Docker setup locally
 - Execute public example scenarios from Python
-- Reuse mirrored shared scenario logic from the app
 - Inspect public V&V assets and workflows
 
 
@@ -65,7 +64,6 @@ Start here:
 
 - [`docker/`](docker/) contains the public local deployment setup for JuPedSim Web.
 - [`standards/`](standards/) contains the local Python runner, notebooks, and example scenarios.
-- [`shared/`](shared/) contains mirrored public-safe shared modules used by the local scenario runner.
 - [`tests/vv/`](tests/vv/) contains verification and validation assets and workflows.
 - [`geometries/`](geometries/) contains public geometry examples and format references.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+testpaths = [
+    "tests",
+    "standards/tests",
+]
 markers = [
     "vv: verification and validation tests",
 ]

--- a/standards/README.md
+++ b/standards/README.md
@@ -12,7 +12,7 @@ The web app is used for **scenario design**. Python is used for
             ↓
     Export scenario ZIP (config.json + geometry.wkt)
             ↓
-    load_scenario("jps_2025_03_07.zip")
+    load_scenario("scenario.zip")
             ↓
     Run simulations in Python
             ↓
@@ -33,17 +33,16 @@ All simulations run **locally**, without relying on the remote server.
 
 This project uses [uv](https://docs.astral.sh/uv/getting-started/installation/) for dependency management.
 
-Create venv and install dependencies:
+Create venv and install dependencies (from the repository root):
 
 ```bash
-cd ..
 uv sync --extra dev
-cd standards
 ```
 
-Run Jupyter directly:
+Run Jupyter from inside this directory:
 
 ```bash
+cd standards
 uv run --project .. jupyter notebook
 ```
 
@@ -61,7 +60,7 @@ and one WKT file.
 ``` python
 from jupedsim_scenarios import load_scenario, run_scenario
 
-scenario = load_scenario("jps_2025_03_07.zip")
+scenario = load_scenario("scenario.zip")
 
 print(scenario.summary())
 

--- a/standards/imo/README.md
+++ b/standards/imo/README.md
@@ -1,0 +1,18 @@
+# IMO
+
+Scenarios and notebooks implementing the IMO MSC.1/Circ.1533 evacuation
+analysis guidelines.
+
+## Status
+
+In progress. Programmatic tests live in
+[`tests/vv/test_imo_*.py`](../../tests/vv/); notebooks for this standard
+have not been authored yet.
+
+## Layout
+
+- `scenario_files/` — exported scenario ZIPs (see the directory's own
+  `README.md` for naming conventions).
+
+When notebooks are added they live at this level next to
+`scenario_files/`, following the layout of `standards/rimea/`.

--- a/standards/imo/scenario_files/README.md
+++ b/standards/imo/scenario_files/README.md
@@ -2,5 +2,6 @@
 
 Placeholder. Add scenarios from the imo standard here as they're authored.
 
-See `scripts/scenarios/README.md` for layout conventions and the
-modern `journeys_v2` schema requirement.
+Scenarios are authored in the JuPedSim web app and exported as ZIPs
+(`config.json` + `geometry.wkt`). See [`standards/README.md`](../../README.md)
+for the loading workflow.

--- a/standards/iso/README.md
+++ b/standards/iso/README.md
@@ -1,0 +1,17 @@
+# ISO
+
+Scenarios and notebooks implementing ISO 20414 (verification and
+validation of building evacuation models).
+
+## Status
+
+Planned. Neither programmatic tests nor notebooks exist yet. Tracking
+issue: see the badge on the top-level README.
+
+## Layout
+
+- `scenario_files/` — exported scenario ZIPs (see the directory's own
+  `README.md` for naming conventions).
+
+When notebooks are added they live at this level next to
+`scenario_files/`, following the layout of `standards/rimea/`.

--- a/standards/iso/scenario_files/README.md
+++ b/standards/iso/scenario_files/README.md
@@ -2,5 +2,6 @@
 
 Placeholder. Add scenarios from the iso standard here as they're authored.
 
-See `scripts/scenarios/README.md` for layout conventions and the
-modern `journeys_v2` schema requirement.
+Scenarios are authored in the JuPedSim web app and exported as ZIPs
+(`config.json` + `geometry.wkt`). See [`standards/README.md`](../../README.md)
+for the loading workflow.

--- a/standards/nist/README.md
+++ b/standards/nist/README.md
@@ -1,0 +1,16 @@
+# NIST
+
+Scenarios and notebooks based on NIST verification and validation
+benchmarks for pedestrian / egress models.
+
+## Status
+
+Planned. Neither programmatic tests nor notebooks exist yet.
+
+## Layout
+
+- `scenario_files/` — exported scenario ZIPs (see the directory's own
+  `README.md` for naming conventions).
+
+When notebooks are added they live at this level next to
+`scenario_files/`, following the layout of `standards/rimea/`.

--- a/standards/nist/scenario_files/README.md
+++ b/standards/nist/scenario_files/README.md
@@ -2,5 +2,6 @@
 
 Placeholder. Add scenarios from the nist standard here as they're authored.
 
-See `scripts/scenarios/README.md` for layout conventions and the
-modern `journeys_v2` schema requirement.
+Scenarios are authored in the JuPedSim web app and exported as ZIPs
+(`config.json` + `geometry.wkt`). See [`standards/README.md`](../../README.md)
+for the loading workflow.

--- a/tests/test_api_surface.py
+++ b/tests/test_api_surface.py
@@ -1,0 +1,67 @@
+"""Smoke test for the public jupedsim_scenarios API.
+
+Fails loudly when upstream renames or removes a symbol that this
+repository depends on. Cheap enough to run on every CI invocation.
+"""
+
+import inspect
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def jps():
+    return pytest.importorskip("jupedsim_scenarios")
+
+
+REQUIRED_SYMBOLS = (
+    "Scenario",
+    "ScenarioResult",
+    "SweepResult",
+    "Trial",
+    "load_scenario",
+    "run_scenario",
+    "run_sweep",
+    "run_sweep_from_factory",
+)
+
+
+def test_required_symbols_exported(jps):
+    missing = [name for name in REQUIRED_SYMBOLS if not hasattr(jps, name)]
+    assert not missing, f"jupedsim_scenarios missing public symbols: {missing}"
+
+
+def test_load_scenario_signature(jps):
+    sig = inspect.signature(jps.load_scenario)
+    params = list(sig.parameters)
+    assert params == ["path"], (
+        f"load_scenario signature drifted: {sig}; "
+        "this repo passes a single positional path argument."
+    )
+
+
+def test_run_scenario_signature(jps):
+    sig = inspect.signature(jps.run_scenario)
+    params = sig.parameters
+    assert "scenario" in params, f"run_scenario lost `scenario` param: {sig}"
+    assert "seed" in params, f"run_scenario lost `seed` param: {sig}"
+    assert params["seed"].kind is inspect.Parameter.KEYWORD_ONLY, (
+        f"run_scenario.seed should remain keyword-only: {sig}"
+    )
+
+
+def test_scenario_class_exposes_used_methods(jps):
+    required = {
+        "set_seed",
+        "set_max_time",
+        "set_model_type",
+        "set_model_params",
+    }
+    missing = required - set(dir(jps.Scenario))
+    assert not missing, f"Scenario lost methods used by this repo: {missing}"
+
+
+def test_scenario_result_exposes_used_attrs(jps):
+    required = {"success", "evacuation_time", "cleanup"}
+    missing = required - set(dir(jps.ScenarioResult))
+    assert not missing, f"ScenarioResult lost attrs used by this repo: {missing}"


### PR DESCRIPTION
## Summary

Addresses all 9 items from the architecture review:

| # | Issue | Fix |
|---|-------|-----|
| 1 | README listed `shared/` dir that doesn't exist | Remove the reference |
| 2 | Three test homes, no unified `pytest` entry | Add `testpaths` to `pyproject.toml` |
| 3 | Inconsistent CI path filters; no caching | Add filters to `scenario-examples.yml`; enable `uv` cache on all workflows |
| 4 | `standards/{imo,iso,nist}/` look abandoned | Add per-dir README explaining status (planned/wip) |
| 5 | `uv.lock` masks upstream API drift until lock bump | New `upstream-drift.yml` weekly workflow that upgrades to latest `jupedsim-scenarios` and runs tests |
| 6 | `standards/README` setup diverged from root; stale `jps_2025_03_07.zip` example | Align with root README; replace with generic `scenario.zip` |
| 7 | Notebook-in-git policy implicit | Document in CONTRIBUTING (keep outputs, recommend nbdime, weekly CI catches drift) |
| 8 | No onboarding doc | New `CONTRIBUTING.md` |
| 9 | Implicit dependency on `jupedsim_scenarios` API surface | New `tests/test_api_surface.py` smoke test (imports + signatures) |

## Behavior changes

- `pytest` from root now collects `tests/` + `standards/tests/` in one command.
- `scenario-examples.yml` no longer fires on every push/PR (path-filtered).
- New weekly workflow opens a tracking issue (label `upstream-drift`) if the latest `jupedsim-scenarios` release breaks this repo.

## Test plan

- [ ] CI green on this PR (no behavior changes to existing tests).
- [ ] `uv run --extra dev pytest` collects the new `tests/test_api_surface.py` and all prior tests.
- [ ] Manual trigger of `upstream-drift.yml` (workflow_dispatch) passes against current release.
- [ ] Manual trigger of `notebooks.yml` (workflow_dispatch) still passes.