### PR TITLE
docs(readme): add Docker Hub pulls + latest-tag badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![IMO Tests](https://github.com/PedestrianDynamics/jupedsim-web-community/actions/workflows/imo.yml/badge.svg)](https://github.com/PedestrianDynamics/jupedsim-web-community/actions/workflows/imo.yml)
 [![RiMEA Tests](https://github.com/PedestrianDynamics/jupedsim-web-community/actions/workflows/rimea.yml/badge.svg)](https://github.com/PedestrianDynamics/jupedsim-web-community/actions/workflows/rimea.yml)
 [![ISO Tests](https://img.shields.io/badge/ISO%20Tests-planned-lightgrey)](https://github.com/PedestrianDynamics/jupedsim-web-community/issues)
+[![Docker Pulls](https://img.shields.io/docker/pulls/jupedsim/jupedsim-web)](https://hub.docker.com/r/jupedsim/jupedsim-web)
+[![Docker Image Version](https://img.shields.io/docker/v/jupedsim/jupedsim-web?sort=semver&label=docker%20tag)](https://hub.docker.com/r/jupedsim/jupedsim-web/tags)
 
 [![Watch on YouTube](https://img.youtube.com/vi/MGj0Nyumdms/0.jpg)](https://www.youtube.com/watch?v=MGj0Nyumdms)
 


### PR DESCRIPTION
## Summary

Mirrors the badges just added to `Web-Based-Jupedsim#400` so this community-facing repo also surfaces:

- [Docker Pulls](https://hub.docker.com/r/jupedsim/jupedsim-web) — adoption signal
- [Docker Image Version](https://hub.docker.com/r/jupedsim/jupedsim-web/tags) — currently published tag

Both for `jupedsim/jupedsim-web`, the all-in-one image users actually pull to self-host.

## Test plan

- [x] Badge URLs render against the live `jupedsim/jupedsim-web` repo on Docker Hub.