### PR TITLE
docs(readme): add PyPI version badges for jupedsim and jupedsim-scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![ISO Tests](https://img.shields.io/badge/ISO%20Tests-planned-lightgrey)](https://github.com/PedestrianDynamics/jupedsim-web-community/issues)
 [![Docker Pulls](https://img.shields.io/docker/pulls/jupedsim/jupedsim-web)](https://hub.docker.com/r/jupedsim/jupedsim-web)
 [![Docker Image Version](https://img.shields.io/docker/v/jupedsim/jupedsim-web?sort=semver&label=docker%20tag)](https://hub.docker.com/r/jupedsim/jupedsim-web/tags)
+[![jupedsim on PyPI](https://img.shields.io/pypi/v/jupedsim?label=jupedsim)](https://pypi.org/project/jupedsim/)
+[![jupedsim-scenarios on PyPI](https://img.shields.io/pypi/v/jupedsim-scenarios?label=jupedsim-scenarios)](https://pypi.org/project/jupedsim-scenarios/)
 
 [![Watch on YouTube](https://img.youtube.com/vi/MGj0Nyumdms/0.jpg)](https://www.youtube.com/watch?v=MGj0Nyumdms)
 


### PR DESCRIPTION
Mirrors Web-Based-Jupedsim#401: adds `jupedsim` and `jupedsim-scenarios` PyPI version badges next to the existing Docker tag badge so the README header shows the full version stack at a glance.

Follow-up to #128 — those PyPI commits missed the merge window.