### PR TITLE
fix(nist): repair CI + tighten Verif.2.8/2.9/5.2 to NIST TN 1822 criteria

### DIFF
--- a/standards/nist/scenario_builders/nist1_1_premovement.py
+++ b/standards/nist/scenario_builders/nist1_1_premovement.py
@@ -75,14 +75,15 @@ def build_variants(base_scenario):
     """
     for case in load_cases():
         variant = deepcopy(base_scenario)
-        variant.set_agent_params(
-            DISTRIBUTION_ID,
-            use_premovement=True,
-            premovement_distribution=case.name,
-            premovement_param_a=case.param_a,
-            premovement_param_b=case.param_b,
-        )
-        variant.set_max_time(case.max_simulation_time_s)
+        # Premovement is read straight from the distribution parameters at
+        # simulation-init time; ``set_agent_params`` whitelists only movement
+        # kwargs and rejects ``premovement_*``, so write them in directly.
+        params = variant.distributions[DISTRIBUTION_ID]["parameters"]
+        params["use_premovement"] = True
+        params["premovement_distribution"] = case.name
+        params["premovement_param_a"] = case.param_a
+        params["premovement_param_b"] = case.param_b
+        variant.max_simulation_time = case.max_simulation_time_s
         yield case, variant
 
 

--- a/standards/nist/scenario_builders/nist1_1_premovement.py
+++ b/standards/nist/scenario_builders/nist1_1_premovement.py
@@ -70,8 +70,9 @@ def build_variants(base_scenario):
     """Yield (case, scenario) - one per NIST distribution.
 
     The base scenario is deep-copied for each case so the loaded ZIP is never
-    mutated in place. ``set_agent_params`` is the documented loader API for
-    overriding distribution parameters.
+    mutated in place. Premovement parameters are written straight onto the
+    distribution parameters (see the note below) because ``set_agent_params``
+    rejects the ``premovement_*`` kwargs.
     """
     for case in load_cases():
         variant = deepcopy(base_scenario)

--- a/tests/vv/test_nist.py
+++ b/tests/vv/test_nist.py
@@ -3,11 +3,15 @@
 Reference: Ronchi, Kuligowski, Reneke, Peacock, Nilsson (2013). NIST Technical
 Note 1822. https://nvlpubs.nist.gov/nistpubs/technicalnotes/NIST.TN.1822.pdf
 
-The contributions cover 9 of the 17 NIST verification tests. Tests blocked on
+The contributions cover 10 of the 17 NIST verification tests. Tests blocked on
 JuPedSim simulator features absent from CollisionFreeSpeedModel (Verif.2.5
 visibility, Verif.2.6 FED, Verif.2.7 elevator, Verif.2.10 reduced mobility,
 Verif.3.2 social influence, Verif.3.3 affiliation, Verif.4.1 dynamic exits)
 are documented in standards/nist/README.md and not exercised here.
+
+Two shipped tests exercise NIST's numeric criterion but xfail because it needs a
+CollisionFreeSpeedModel capability the model lacks: Verif.2.9 (no group-cohesion
+model) and Verif.5.2 (no door-flow limiter). See issue #151.
 
 Per-scenario deviations from the NIST originals are logged in
 standards/nist/MODIFICATIONS.md.
@@ -287,44 +291,48 @@ class TestNist24Demographics:
 
 
 class TestNist28Counterflow:
-    """NIST Verif.2.8 - 100 primary agents through a corridor against 0/10/50/100
-    counterflow agents.
+    """NIST Verif.2.8 - 100 primary agents cross a 10 m x 2 m corridor against
+    0/10/50/100 counterflow agents in the far room.
 
-    Acceptance: as counterflow increases, the number of primary agents that
-    complete the corridor must be non-increasing (the model deadlocks at high
-    counterflow, which is consistent with NIST's expected trend taken to its
-    limit case).
+    NIST criterion: the completion time (last primary agent to reach the far
+    room) increases with counterflow. Under CollisionFreeSpeedModel the high
+    counterflow branches deadlock, so a last-arrival *time* is undefined; the
+    equivalent monotone quantity is the number of primary agents that reach the
+    far room within a fixed, *equal* time budget, which must be non-increasing
+    as counterflow grows. Observed on seed 42: [100, 100, 1, 0].
     """
 
-    BUDGET_BY_CF = {0: 400, 10: 500, 50: 400, 100: 400}
+    BUDGET_S = 400
+    # The two 10 m rooms bracket a 10 m corridor, so the far room starts at
+    # x = 20 m. An agent that reaches it is absorbed at the far exit (x >= 29.7),
+    # so its *last* recorded position lies in the far room - counting a fixed
+    # crossing frame (x >= 29.7) misses every absorbed agent and reads 0.
+    FAR_ROOM_X = 20.0
 
-    def test_evacuated_counts_monotonic(self):
+    def test_completion_non_increasing_with_counterflow(self):
         load_branches = _load_builder("nist2_8_counterflow").load_branches
 
-        evacuated_counts = []
+        reached = []
         for branch in load_branches():
             scenario = load_scenario(str(branch.scenario_zip))
-            scenario.max_simulation_time = self.BUDGET_BY_CF[branch.counterflow_agents]
+            scenario.max_simulation_time = self.BUDGET_S
             result = run_scenario(scenario, seed=42)
             try:
-                df = result.trajectory_dataframe()
-                primary_ids = {
-                    int(aid)
-                    for aid, sub in df.sort_values(["id", "frame"]).groupby("id")
-                    if sub.iloc[0].x < 5.0  # primary distribution spawns on the left
-                }
-                evac = sum(
-                    1
-                    for aid in primary_ids
-                    if (df[df.id == aid].x >= 29.7).any()
+                df = result.trajectory_dataframe().sort_values(["id", "frame"])
+                grouped = df.groupby("id")
+                first_x = grouped.first().x
+                last_x = grouped.last().x
+                # Primary population spawns in the near room (x < 5).
+                primary = first_x[first_x < 5.0].index
+                reached.append(
+                    sum(1 for aid in primary if last_x[aid] >= self.FAR_ROOM_X)
                 )
-                evacuated_counts.append(evac)
             finally:
                 result.cleanup()
 
-        deltas = np.diff(evacuated_counts)
+        deltas = np.diff(reached)
         assert (deltas <= 0).all(), (
-            f"evacuated counts not monotonic in counterflow: {evacuated_counts}"
+            f"primary completions not non-increasing in counterflow: {reached}"
         )
 
 
@@ -334,13 +342,12 @@ class TestNist28Counterflow:
 
 
 class TestNist29Groups:
-    """NIST Verif.2.9 - Group 1 (4 fast + 1 slow) and Group 2 (10 slow).
-
-    The source ``group_id`` parameter was stripped (the JuPedSim loader has no
-    native group cohesion). This test verifies the scenario loads, runs, and
-    produces a trajectory; the qualitative "Group 1 stays together" property
-    is not enforced by the simulator.
+    """NIST Verif.2.9 - Group 1 (4 @1.25 m/s + 1 @0.5 m/s) must reach the exit
+    together (arrival spread <= 10 s); Group 2 (10 @0.2 m/s) shares the room.
     """
+
+    GROUP1_SIZE = 5
+    MAX_SPREAD_S = 10.0  # NIST TN 1822 section 3.1.2, Verif.2.9.
 
     def test_runs_without_error(self):
         scenario = _load("Nist-2-9-groups")
@@ -349,6 +356,32 @@ class TestNist29Groups:
             assert result.total_agents == 15
             df = result.trajectory_dataframe()
             assert len(df) > 0
+        finally:
+            result.cleanup()
+
+    @pytest.mark.xfail(
+        reason="CollisionFreeSpeedModel has no group-cohesion model, so the "
+        "0.5 m/s member of Group 1 lags the 1.25 m/s members (spread ~24 s > "
+        "10 s). Needs a group sub-model; tracked in issue #151.",
+        raises=AssertionError,
+        strict=True,
+    )
+    def test_group1_arrives_together(self):
+        scenario = _load("Nist-2-9-groups")
+        result = run_scenario(scenario, seed=42)
+        try:
+            df = result.trajectory_dataframe().sort_values(["id", "frame"])
+            grouped = df.groupby("id")
+            first_y = grouped.first().y
+            # Exit time per agent = last recorded frame (absorbed at the exit).
+            exit_time = grouped.frame.max() / result.frame_rate
+            # Group 1 spawns in the top zone (y ~16-19.5); Group 2 sits lower
+            # (y ~8-12), so the five highest spawn-y agents are exactly Group 1.
+            group1 = first_y.sort_values(ascending=False).head(self.GROUP1_SIZE).index
+            spread = exit_time[group1].max() - exit_time[group1].min()
+            assert spread <= self.MAX_SPREAD_S, (
+                f"Group 1 arrival spread {spread:.1f} s exceeds {self.MAX_SPREAD_S} s"
+            )
         finally:
             result.cleanup()
 
@@ -450,6 +483,11 @@ class TestNist51Congestion:
     Acceptance: peak density at the room exit > peak density in the corridor
     midsection (i.e. congestion forms at the room exit; flow is steadier in
     the corridor).
+
+    NIST also expects congestion at the base of the stairs, but this ZIP models
+    a plain room -> corridor -> exit with no stair speed-factor zone, so that
+    half of the expected result is not exercised. Adding a stair zone (JuPedSim
+    supports it) is scope-deferred; see issue #151.
     """
 
     def test_peak_density_higher_at_room_exit(self):
@@ -479,38 +517,49 @@ class TestNist51Congestion:
 
 
 # ---------------------------------------------------------------------------
-# Verif.5.2 - Maximum flow rates (Mode B - emergent flow validation)
+# Verif.5.2 - Maximum flow rates
 # ---------------------------------------------------------------------------
 
 
 class TestNist52MaxFlow:
-    """NIST Verif.5.2 - Mode B emergent-flow validation.
+    """NIST Verif.5.2 - 100 agents evacuate an 8 m x 5 m room through a 1 m exit.
 
-    The CollisionFreeSpeedModel has no built-in door-flow limiter. We record
-    the peak emergent flow through the 1 m exit and verify it is positive +
-    finite. The 1.33 p/m/s IMO reference is informational only at this stage.
+    For an emergent-flow model NIST section 3.1.5 reads this as a non-exceedance
+    check: the sustained specific flow through the exit must not exceed the IMO
+    MSC/Circ.1238 reference of 1.33 p/m/s.
     """
 
     EXIT_WIDTH_M = 1.0
+    IMO_MAX_FLOW = 1.33  # p/m/s, IMO MSC/Circ.1238 (via NIST TN 1822 section 3.1.5).
 
-    def test_emergent_flow_finite(self):
+    @pytest.mark.xfail(
+        reason="CollisionFreeSpeedModel has no door-flow limiter, so the "
+        "emergent specific flow through the 1 m exit (~5 p/m/s on seed 42) "
+        "exceeds the IMO 1.33 p/m/s reference. Needs a flow-limiting exit "
+        "model; tracked in issue #151.",
+        raises=AssertionError,
+        strict=True,
+    )
+    def test_flow_within_imo_reference(self):
         scenario = _load("Nist-5-2-max-flow")
         result = run_scenario(scenario, seed=42)
         try:
             assert result.agents_evacuated > 0
             df = result.trajectory_dataframe().sort_values(["id", "frame"])
-            exit_times = []
-            for _aid, sub in df.groupby("id"):
-                crossed = sub[sub.x <= 0.3]
-                if len(crossed):
-                    exit_times.append(crossed.iloc[0].frame / result.frame_rate)
-            assert len(exit_times) > 0, "no agent crossed the exit"
-            # 1 s sliding-window peak flow.
-            exit_times = np.array(sorted(exit_times))
-            peak = 0.0
-            for t in np.arange(1.0, exit_times.max() + 1.0, 1.0):
-                in_window = ((exit_times > t - 1.0) & (exit_times <= t)).sum()
-                peak = max(peak, in_window / self.EXIT_WIDTH_M)
-            assert peak > 0.0 and np.isfinite(peak)
+            grouped = df.groupby("id")
+            # Exit time per agent = last recorded frame (absorbed at the exit);
+            # an agent that evacuated ends within a door-width of the exit.
+            last = grouped.last()
+            evac = last[last.x <= 0.6].index
+            exit_times = np.sort(
+                (grouped.frame.max()[evac] / result.frame_rate).values
+            )
+            assert len(exit_times) > 0, "no agent reached the exit"
+            # Sustained specific flow over the egress period.
+            span = exit_times.max() - exit_times.min()
+            flow = len(exit_times) / span / self.EXIT_WIDTH_M
+            assert flow <= self.IMO_MAX_FLOW, (
+                f"specific flow {flow:.2f} p/m/s exceeds IMO {self.IMO_MAX_FLOW} p/m/s"
+            )
         finally:
             result.cleanup()

--- a/tests/vv/test_nist.py
+++ b/tests/vv/test_nist.py
@@ -544,20 +544,18 @@ class TestNist52MaxFlow:
         scenario = _load("Nist-5-2-max-flow")
         result = run_scenario(scenario, seed=42)
         try:
-            assert result.agents_evacuated > 0
+            # Every agent evacuates, so each agent's last recorded frame is its
+            # absorption (exit) time - no spatial cutoff needed.
+            assert result.agents_remaining == 0, "not all agents evacuated"
             df = result.trajectory_dataframe().sort_values(["id", "frame"])
-            grouped = df.groupby("id")
-            # Exit time per agent = last recorded frame (absorbed at the exit);
-            # an agent that evacuated ends within a door-width of the exit.
-            last = grouped.last()
-            evac = last[last.x <= 0.6].index
             exit_times = np.sort(
-                (grouped.frame.max()[evac] / result.frame_rate).values
+                (df.groupby("id").frame.max() / result.frame_rate).values
             )
             assert len(exit_times) > 0, "no agent reached the exit"
-            # Sustained specific flow over the egress period.
+            # Sustained specific flow over the egress period (first to last exit),
+            # using the runner's own evacuated count.
             span = exit_times.max() - exit_times.min()
-            flow = len(exit_times) / span / self.EXIT_WIDTH_M
+            flow = result.agents_evacuated / span / self.EXIT_WIDTH_M
             assert flow <= self.IMO_MAX_FLOW, (
                 f"specific flow {flow:.2f} p/m/s exceeds IMO {self.IMO_MAX_FLOW} p/m/s"
             )

--- a/tests/vv/test_nist.py
+++ b/tests/vv/test_nist.py
@@ -304,7 +304,7 @@ class TestNist28Counterflow:
         evacuated_counts = []
         for branch in load_branches():
             scenario = load_scenario(str(branch.scenario_zip))
-            scenario.set_max_time(self.BUDGET_BY_CF[branch.counterflow_agents])
+            scenario.max_simulation_time = self.BUDGET_BY_CF[branch.counterflow_agents]
             result = run_scenario(scenario, seed=42)
             try:
                 df = result.trajectory_dataframe()


### PR DESCRIPTION
## Why

The **NIST Tests** workflow has been red on `main` since #127 ([run 29186992365](https://github.com/PedestrianDynamics/jupedsim-web-community/actions/runs/29186992365)): 5 of 16 tests error at collection/run against the pinned `jupedsim-scenarios==0.6.4.1`. While fixing that I verified each shipped test against the primary source (NIST TN 1822) and tightened three whose pass criteria didn't actually check what NIST specifies. Addresses the Section 1 faithfulness items in #151.

## 1. CI fix (commit 1)

Two calls used an API no published `jupedsim-scenarios` provides:
- `Scenario.set_max_time()` — **removed in 0.5.x**; the setter is now the `max_simulation_time` property.
- `set_agent_params(premovement_*, use_premovement=…)` — `set_agent_params` whitelists movement kwargs only; premovement is read straight from the distribution parameters at simulation-init time.

Both fixed against the pinned 0.6.4.1. No version bump (even latest 0.6.4.4 lacks these).

## 2. Criteria tightening (commit 2)

| Test | Before | After |
|------|--------|-------|
| **Verif.2.8** counterflow | counted agents at a fixed crossing frame `x>=29.7` — but agents are absorbed at the exit, so it was `[0,0,0,0]` and **passed vacuously**; asymmetric budgets `{0:400,10:500,50:400,100:400}` | count by **last** position reaching the far room, single **equal 400 s** budget → `[100,100,1,0]`, non-increasing with margin |
| **Verif.5.2** max flow | report-only `flow>0/finite`, 1.33 "informational"; invented "Mode A/B" naming | NIST non-exceedance: sustained specific flow ≤ **1.33 p/m/s** (IMO MSC/Circ.1238) |
| **Verif.2.9** groups | only asserted the sim runs | NIST **10 s** Group-1 arrival-spread criterion |

## 3. Deviations that can't be fixed (missing simulator features)

Documented as **strict `xfail`** (they flip to failures via XPASS if the capability is ever added) and tracked in #151:
- **Verif.5.2** — CollisionFreeSpeedModel has no door-flow limiter; emergent flow ≈ **5 p/m/s** ≫ 1.33.
- **Verif.2.9** — no native group cohesion; the 0.5 m/s member lags, spread ≈ **24 s** ≫ 10 s.

Also noted in-code: **Verif.5.1**'s stair-base congestion is not exercised (the ZIP has no stair speed-factor zone — constructible, scope-deferred, not a feature gap).

## Verification

`pytest tests/vv/test_nist.py` locally (py3.12, jupedsim-scenarios 0.6.4.1): **15 passed, 2 xfailed** (was 5 failed, 11 passed).

Cross-referenced against NIST TN 1822 §3.1.1–3.1.5 (Table 1). The remaining 7 uncovered tests (2.5/2.6/2.7/2.10/3.2/3.3/4.1) are simulator-feature-blocked, per #151 §2.