### PR TITLE
ci(rimea): trigger RiMEA tests on standards/rimea changes

### DIFF
--- a/.github/workflows/rimea.yml
+++ b/.github/workflows/rimea.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "standards/rimea/**"
       - "tests/vv/test_rimea.py"
       - "tests/vv/vv_helpers.py"
       - "pyproject.toml"
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - "standards/rimea/**"
       - "tests/vv/test_rimea.py"
       - "tests/vv/vv_helpers.py"
       - "pyproject.toml"


### PR DESCRIPTION
## Why

The `RiMEA Tests` workflow (`rimea.yml`) has existed since 2026-05-22 but its `paths` filter watches only `tests/vv/test_rimea.py`, `vv_helpers.py`, `pyproject.toml`, `uv.lock`, and itself — **not** the `standards/rimea/**` scenario files, notebooks, and builders that the tests actually load.

Consequence: a PR that changes only scenarios/notebooks/builders never runs the RiMEA suite. That's exactly why **#144** (RiMEA Tests Implementation — 35 files, all under `standards/rimea/**`) shows *"no checks reported"*.

`nist.yml` already watches `standards/nist/**`; this brings `rimea.yml` in line.

## Change

Add `standards/rimea/**` to both the `push` and `pull_request` path filters.

## Verified

`tests/vv/test_rimea.py` runs green against the #144 head locally (py3.12, jupedsim-scenarios 0.6.4.1): **18 passed, 3 skipped** (the skips are intentional feature placeholders). With this filter, that same suite will run automatically on `standards/rimea/**` PRs.

Note: fork PRs (like #144) additionally require a maintainer to approve workflow runs (`action_required`) — this change makes the job *eligible* to run; approval is still the separate manual gate.