### PR TITLE
docs(nist): resolve remaining #151 faithfulness notes (1.1, 3.1, 2.9, 5.2)

### DIFF
--- a/standards/nist/MODIFICATIONS.md
+++ b/standards/nist/MODIFICATIONS.md
@@ -79,7 +79,7 @@ allocation when the ZIP also contains a `journeys_v2` block (with
 `id` / `name` / `color` / `sequence`) plus per-distribution
 `journey_weights`. When only legacy `journeys` is present the loader
 falls back to nearest-exit routing, which silently misroutes agents in
-multi-exit scenarios (notably Verif.3.1, where 2/23 agents from Room 10
+multi-exit scenarios (notably Verif.3.1, where 2/13 agents from Room 10
 went to the secondary exit instead of their allocated main exit).
 
 Every ZIP in this contribution therefore ships **both schemas**:
@@ -93,7 +93,7 @@ Every ZIP in this contribution therefore ships **both schemas**:
   to its single journey.
 
 With this dual-schema ZIP the canonical loader enforces the NIST-allocated
-routes strictly (verified: 23/23 agents reach their allocated exit on
+routes strictly (verified: 13/13 agents reach their allocated exit on
 Verif.3.1). The legacy block keeps the ZIP round-trippable through the
 web app.
 
@@ -190,10 +190,10 @@ Not shipped. Requires reduced-mobility / per-agent size profiles.
 - This supersedes earlier attempts that rebuilt the geometry
   parametrically — see `_staging/replace_s12_with_rimea10.py` for the
   one-line `shutil.copy` that wires rimea-10 in.
-- Agent count: 13 (rimea-10's value). NIST's original spec asks for
-  23 agents (2 per room except Room 3 with 1); the route-allocation
-  semantics are independent of agent count, so the rimea-10 count
-  is kept.
+- Agent count: 13 (one per room, plus a second in one room; rimea-10's
+  value). NIST TN 1822 §3.1.3 says "23 persons", but that is a typo in the
+  guideline — the Figure 8 layout has 12 rooms, so 13 is the faithful count.
+  The allocation split (8 rooms → main, 4 → secondary) matches the standard.
 
 ### B13. Verif.3.2 — Social influence (S13.x) — PENDING
 
@@ -216,17 +216,18 @@ Not shipped. Requires runtime exit toggling (NIST closes Exit 1 at t = 1 s).
 
 ### B17. Verif.5.2 — Maximum flow rates (S17)
 
-- **NIST Mode B (emergent-flow validation)** is the default because the
+- **The emergent-flow interpretation** is the default because the
   CollisionFreeSpeedModel has no built-in door-flow limiter. NIST TN 1822
-  Verif.5.2 explicitly offers two interpretations: (A) verification of a
-  restricted-flow model — set the exit cap and check it is enforced; or (B)
-  validation of emergent flow — let flow emerge and check it stays below
-  the threshold. The notebook compares the recorded flow against the
-  1.33 p/m/s reference (IMO MSC/Circ.1238) as a post-run threshold.
+  Verif.5.2 offers two readings: (1) verification of a restricted-flow model —
+  set the exit cap and check it is enforced; or (2) validation of emergent
+  flow — let flow emerge and check it stays below the threshold. The notebook
+  compares the recorded flow against the 1.33 p/m/s reference
+  (IMO MSC/Circ.1238) as a post-run threshold. ("Mode A/B" naming used in
+  earlier drafts is not NIST terminology and has been dropped.)
 - The exit retains the canonical loader fields `max_throughput: 1.33` and
-  `enable_throughput_throttling: false`. To switch to Mode A (when the
-  runner under test supports throttled exits), the notebook can flip
-  `enable_throughput_throttling` to `true` after loading.
+  `enable_throughput_throttling: false`. To exercise the restricted-flow
+  reading (when the runner under test supports throttled exits), the notebook
+  can flip `enable_throughput_throttling` to `true` after loading.
 - **Schema cleanup** (A3): only the top-level `metadata` block was removed.
 
 ## C. Items intentionally NOT changed

--- a/standards/nist/README.md
+++ b/standards/nist/README.md
@@ -33,11 +33,19 @@ For deviations from the NIST original specifications see
 | Verif.3.3  | Affiliation                            | pending  | requires affiliation component |
 | Verif.4.1  | Dynamic availability of exits          | pending  | requires runtime exit toggling |
 | Verif.5.1  | Congestion                             | covered  | `Nist-5-1-congestion.zip` |
-| Verif.5.2  | Maximum flow rates                     | covered  | `Nist-5-2-max-flow.zip` (NIST Mode B - emergent flow) |
+| Verif.5.2  | Maximum flow rates                     | covered* | `Nist-5-2-max-flow.zip` (emergent-flow non-exceedance check) |
 
-\* Verif.2.9 ships geometry + journeys but the original config used a custom
-`group_id` parameter that was stripped during cleaning; the notebook will need
-to apply group behaviour through whatever mechanism the loader supports.
+\* **Verif.2.9** and **Verif.5.2** run and produce trajectories, but their one
+NIST numeric criterion needs a `CollisionFreeSpeedModel` capability the model
+lacks, so each is a strict `xfail` (see issue #151):
+- Verif.2.9 expects Group 1 to reach the exit together (arrival spread ≤ 10 s).
+  There is no native group-cohesion model, so the 0.5 m/s member lags the
+  1.25 m/s members (spread ~24 s). The original config's custom `group_id`
+  parameter was stripped during cleaning.
+- Verif.5.2 (emergent-flow reading of NIST §3.1.5) expects the sustained
+  specific flow through the 1 m exit to stay under the IMO 1.33 p/m/s
+  reference. There is no door-flow limiter, so the emergent flow (~5 p/m/s)
+  exceeds it.
 
 ## Modification highlights vs NIST originals
 
@@ -52,11 +60,14 @@ See [`MODIFICATIONS.md`](MODIFICATIONS.md) for the full audit trail. Summary:
   specifies.
 - **Verif.3.1 (S12)** geometry was rebuilt to NIST Figure 8 (12 rooms around a
   1 m corridor + vestibule); the previous tree had a bare 18 m x 11 m
-  rectangle.
-- **Verif.5.2 (S17)** uses NIST's Mode B (emergent-flow validation), because
-  the JuPedSim CollisionFreeSpeedModel has no built-in door-flow limiter. The
-  1.33 p/m/s value (IMO MSC/Circ.1238) is a post-run comparison threshold,
-  not an input cap applied to the exit.
+  rectangle. Population is **13 agents** (one per room, plus one). NIST TN 1822
+  §3.1.3 says "23 persons", but that is a typo in the guideline — the Figure 8
+  layout has 12 rooms, so 13 is the faithful count. The allocation split
+  (8 rooms → main exit, 4 → secondary) matches the standard.
+- **Verif.5.2 (S17)** uses the emergent-flow non-exceedance interpretation of
+  NIST §3.1.5, because the JuPedSim CollisionFreeSpeedModel has no built-in
+  door-flow limiter. The 1.33 p/m/s value (IMO MSC/Circ.1238) is a post-run
+  comparison threshold, not an input cap applied to the exit.
 - **Terminology**: "pre-evacuation time" used throughout in place of mixed
   "pre-movement / immediate response / instant response / response time 0"
   wording from earlier V&V iterations. NIST TN 1822 uses "pre-evacuation

--- a/standards/nist/nist2_9_groups.ipynb
+++ b/standards/nist/nist2_9_groups.ipynb
@@ -201,7 +201,9 @@
    "id": "5e8b1b83",
    "metadata": {},
    "source": [
-    "## Acceptance"
+    "## Acceptance\n",
+    "\n",
+    "NIST Verif.2.9 requires Group 1 to reach the exit **together** — the arrival spread must be ≤ 10 s. The CollisionFreeSpeedModel has no group-cohesion model, so the 0.5 m/s member lags the 1.25 m/s members and the spread is ~24 s. The test (`test_nist.py`) encodes this criterion as a strict `xfail`; see issue #151."
    ]
   },
   {

--- a/standards/nist/nist5_2_max_flow.ipynb
+++ b/standards/nist/nist5_2_max_flow.ipynb
@@ -5,9 +5,9 @@
    "id": "5d4dbe39",
    "metadata": {},
    "source": [
-    "# NIST TN 1822 — Verif.5.2: Maximum flow rates (Mode B - emergent flow)\n",
+    "# NIST TN 1822 — Verif.5.2: Maximum flow rates\n",
     "\n",
-    "100 agents in an 8 m x 5 m room with a 1 m exit. NIST Mode B: let flow emerge from agent dynamics and verify it stays below the 1.33 p/m/s threshold (IMO MSC/Circ.1238). To switch to Mode A (throttled exit), set `enable_throughput_throttling=True` on the exit."
+    "100 agents in an 8 m x 5 m room with a 1 m exit. The CollisionFreeSpeedModel has no door-flow limiter, so this is the emergent-flow reading of NIST §3.1.5: let flow emerge from agent dynamics and check whether it stays below the 1.33 p/m/s reference (IMO MSC/Circ.1238). To exercise the restricted-flow reading instead (a runner with a throttled exit), set `enable_throughput_throttling=True` on the exit."
    ]
   },
   {
@@ -228,7 +228,7 @@
    "id": "754c2b48",
    "metadata": {},
    "source": [
-    "## Acceptance (Mode B)"
+    "## Acceptance (non-exceedance)"
    ]
   },
   {
@@ -257,9 +257,11 @@
    "source": [
     "peak_flow = flow.flow_p_per_m_s.max()\n",
     "print(f'peak emergent flow = {peak_flow:.3f} p/m/s; threshold = {THRESHOLD_PMS} p/m/s')\n",
-    "# Mode B is validation, not a hard pass/fail: we report only.\n",
+    "# Non-exceedance check. The test (test_nist.py) asserts flow <= threshold as a\n",
+    "# strict xfail; here we report, since CFSM's emergent flow is expected to exceed\n",
+    "# the IMO reference (no door-flow limiter).\n",
     "if peak_flow > THRESHOLD_PMS:\n",
-    "    print('WARNING: emergent flow exceeds the IMO reference threshold')\n",
+    "    print('NOTE: emergent flow exceeds the IMO reference threshold (expected for CFSM)')\n",
     "result.cleanup()"
    ]
   }

--- a/standards/nist/scenario_builders/nist1_1_premovement.py
+++ b/standards/nist/scenario_builders/nist1_1_premovement.py
@@ -27,10 +27,12 @@ from utils.premovement_distributions import (  # type: ignore  # noqa: E402
 
 DISTRIBUTION_ID = "jps-distributions_0"
 
-# NIST TN 1822 section 3.1.1 parameters - hard-coded so we never depend on
-# upstream PREMOVEMENT_PRESETS defaults (which use U(0, 60) for uniform,
-# not NIST's U(10, 100)). Gamma/lognormal/weibull defaults DO match NIST
-# but we list them explicitly for traceability.
+# Distribution parameters for each case. NIST TN 1822 section 3.1.1 names
+# only the distribution *types* (uniform / normal / log-normal / etc.), not
+# numeric parameters - these values are the model's built-in premovement
+# presets, hard-coded here so we never depend on upstream PREMOVEMENT_PRESETS
+# defaults. Uniform is overridden to U(10, 100) (the upstream default is
+# U(0, 60)); gamma/lognormal/weibull match the presets, listed for traceability.
 NIST_CASES = {
     "uniform":   {"a": 10.0,    "b": 100.0,   "max_time_s": 180},
     "gamma":     {"a": 1.291,   "b": 103.901, "max_time_s": 1200},
@@ -55,7 +57,8 @@ class PreEvacCase:
 
 
 def load_cases() -> list[PreEvacCase]:
-    """Return the four NIST pre-evac cases with the parameters from TN 1822."""
+    """Return the four pre-evac cases (distribution types per NIST TN 1822
+    section 3.1.1; numeric parameters as configured in ``NIST_CASES``)."""
     return [
         PreEvacCase(
             name=name,

--- a/tests/vv/test_nist.py
+++ b/tests/vv/test_nist.py
@@ -395,6 +395,11 @@ class TestNist31RouteAllocation:
     """NIST Verif.3.1 - 12 rooms around a 1 m corridor; main exit serves rooms
     1-4 and 7-10, secondary exit serves rooms 5, 6, 11, 12.
 
+    Population is 13 agents (one per room, plus one). NIST TN 1822 section
+    3.1.3 states "23 persons", but that is a typo in the guideline - the
+    Figure 8 layout has 12 rooms, so 13 is the faithful count. The allocation
+    split (8 rooms -> main, 4 -> secondary) matches the standard.
+
     Acceptance: every agent must end at the exit allocated by its journey.
     The walkable polygon is rebuilt parametrically; see MODIFICATIONS.md
     section B12.


### PR DESCRIPTION
Closes the documentation/provenance items in #151 §1 that #155 didn't cover. **No test behaviour changes** — the 2.9/5.2 numeric criteria already landed as strict `xfail`s in #155; this aligns the surrounding docs.

## Changes

- **Verif.1.1 (provenance)** — the builder called its `a/b` values "NIST TN 1822 §3.1.1 parameters". NIST names only the distribution *types* (uniform/normal/log-normal); these numbers are the model's built-in premovement presets (uniform overridden to U(10,100)). Comment + docstring reworded.
- **Verif.3.1 (13 vs 23 agents)** — per maintainer: NIST §3.1.3's "23 persons" is a **typo in the guideline**; the Figure 8 layout has 12 rooms, so **13** (one per room, plus one) is faithful. Documented in the test docstring + README, and fixed `MODIFICATIONS.md`, which contradicted the shipped scenario (claimed "23/23 agents", "2 per room").
- **Verif.5.2 / 2.9 ("Mode A/B" + criteria)** — dropped the invented "Mode A/Mode B" naming (README, `MODIFICATIONS.md`, `nist5_2` notebook); it's not NIST terminology. Kept NIST's actual two-interpretation wording. Added the **10 s** (2.9) and **1.33 p/m/s** (5.2) criteria and their CFSM feature-gap explanations to the README coverage footnote and the 2.9 notebook `## Acceptance` cell.

## Verification

`pytest tests/vv/test_nist.py --collect-only` → 17 tests collected; ruff introduces no new findings; both edited notebooks pass `nbformat.validate`. Changes are comments/docstrings/markdown only.

## Remaining in #151 (out of scope here)

§2 feature-blocked tests (2.5/2.6/2.7/2.10/3.2/3.3/4.1) and §3 repo policy (assets git-vs-LFS, flaky RiMEA13 FD test).