### PR TITLE
feat(vv): manifest-driven standards coverage dashboard (GitHub Pages)

### DIFF
--- a/.github/workflows/vv.yml
+++ b/.github/workflows/vv.yml
@@ -9,6 +9,16 @@ on:
     - cron: "0 6 * * 1"  # Weekly Monday 06:00 UTC
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+  issues: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: false
+
 jobs:
   vv-tests:
     runs-on: ubuntu-latest
@@ -38,85 +48,13 @@ jobs:
       with:
         paths: results/vv-tests.xml
 
-    - name: V&V summary table
+    # Build the standards coverage report (HTML dashboard + Markdown mirror)
+    # from the manifest joined to the live JUnit results. Stdlib only.
+    - name: Generate standards coverage report
       if: always()
       run: |
-        python3 -c "
-        import xml.etree.ElementTree as ET, pathlib, os, sys, datetime
-
-        sys.path.insert(0, 'tests/vv')
-        from test_registry import TEST_MAP
-
-        xml = pathlib.Path('results/vv-tests.xml')
-        if not xml.exists():
-            print('No JUnit XML found')
-            raise SystemExit(0)
-
-        tree = ET.parse(xml)
-
-        rows = []
-        for tc in tree.iter('testcase'):
-            cls = tc.get('classname', '').split('.')[-1]
-            fail = tc.find('failure')
-            skip = tc.find('skipped')
-            if skip is not None:
-                result = 'SKIP'
-            elif fail is not None:
-                result = 'FAIL'
-            else:
-                result = 'PASS'
-
-            test_name, ref, criterion = cls, '\u2014', tc.get('name', '')
-            for prefix, (tn, r, c) in TEST_MAP.items():
-                if cls.startswith(prefix):
-                    test_name, ref, criterion = tn, r, c
-                    break
-
-            rows.append((test_name, ref, criterion, result))
-
-        # Deduplicate (parametrized tests share the same class)
-        seen = set()
-        unique_rows = []
-        for row in rows:
-            key = row[0]
-            if key in seen:
-                for i, r in enumerate(unique_rows):
-                    if r[0] == key and row[3] == 'FAIL':
-                        unique_rows[i] = row
-                continue
-            seen.add(key)
-            unique_rows.append(row)
-        rows = unique_rows
-
-        lines = []
-        lines.append('## V&V Test Results\n')
-        lines.append(f'*Last updated: {datetime.datetime.utcnow().strftime(\"%Y-%m-%d %H:%M UTC\")}*\n')
-        lines.append('| Test | Reference | Criterion | Result |')
-        lines.append('|------|-----------|-----------|--------|')
-        for test_name, ref, crit, res in rows:
-            icon = {'PASS': ':white_check_mark:', 'FAIL': ':x:', 'SKIP': ':fast_forward:'}[res]
-            lines.append(f'| {test_name} | {ref} | {crit} | {icon} {res} |')
-
-        total = len(rows)
-        passed = sum(1 for r in rows if r[3] == 'PASS')
-        failed = sum(1 for r in rows if r[3] == 'FAIL')
-        skipped = sum(1 for r in rows if r[3] == 'SKIP')
-        summary_line = f'**{passed}/{total} passed'
-        if failed: summary_line += f', {failed} failed'
-        if skipped: summary_line += f', {skipped} skipped'
-        summary_line += '**'
-        lines.append(f'\n{summary_line}')
-
-        md = '\n'.join(lines)
-
-        summary_path = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/stdout')
-        with open(summary_path, 'a') as f:
-            f.write(md + '\n')
-
-        pathlib.Path('results').mkdir(exist_ok=True)
-        with open('results/vv-summary.md', 'w') as f:
-            f.write(md + '\n')
-        "
+        python3 scripts/gen_standards_report.py --junit results/vv-tests.xml --outdir site
+        cat site/summary.md >> "$GITHUB_STEP_SUMMARY"
 
     - name: Update pinned issue
       # Only push/schedule runs on main update the pinned tracking issue.
@@ -127,11 +65,31 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [ -f results/vv-summary.md ]; then
-          jq -n --rawfile body results/vv-summary.md '{"body": $body}' | \
+        if [ -f site/summary.md ]; then
+          jq -n --rawfile body site/summary.md '{"body": $body}' | \
             curl -s -X PATCH \
               -H "Authorization: token $GH_TOKEN" \
               -H "Accept: application/vnd.github+json" \
               -d @- \
               "https://api.github.com/repos/PedestrianDynamics/jupedsim-web-community/issues/67"
         fi
+
+    - name: Upload Pages artifact
+      if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: site
+
+  # Publish the dashboard to GitHub Pages (main only). Requires Pages to be
+  # enabled with "GitHub Actions" as the source (Settings -> Pages).
+  deploy-pages:
+    needs: vv-tests
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 *.ipynb_checkpoints
 *~
+
+# V&V standards coverage manifest (overrides a global *.json ignore some contributors may have)
+!standards/coverage.json

--- a/scripts/gen_standards_report.py
+++ b/scripts/gen_standards_report.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Generate the standards coverage report from the manifest + pytest results.
+
+Reads:
+  - standards/coverage.json  (single source of truth: every test each standard
+    defines, with declared status and the pytest class it maps to)
+  - a JUnit XML from `pytest tests/vv` (live PASS/FAIL/XFAIL/SKIP), optional
+
+Writes:
+  - <outdir>/index.html  : self-contained GitHub Pages dashboard
+  - <outdir>/summary.md  : Markdown mirror for the pinned tracking issue (#67)
+
+Stdlib only, so CI's plain python3 can run it. For pytest-backed rows the live
+JUnit result overrides the manifest's declared status; notebook/pending rows
+keep their declared status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import html
+import json
+import pathlib
+import xml.etree.ElementTree as ET
+
+REPO = "https://github.com/PedestrianDynamics/jupedsim-web-community"
+
+# status -> (label, css class). "covered" is the resolved-pass state.
+STATUS_META = {
+    "pass": ("PASS", "pass"),
+    "fail": ("FAIL", "fail"),
+    "xfail": ("XFAIL", "xfail"),
+    "xpass": ("XPASS", "fail"),
+    "skip": ("SKIP", "skip"),
+    "pending": ("PENDING", "pending"),
+    "notebook": ("NOTEBOOK", "notebook"),
+}
+
+
+def parse_junit(xml_path: pathlib.Path) -> dict:
+    """Return {(class_name, method_name): status} where status is one of
+    pass/fail/xfail/xpass/skip. class_name is the last dotted component of the
+    JUnit classname (e.g. 'TestNist52MaxFlow')."""
+    results: dict = {}
+    if not xml_path or not xml_path.exists():
+        return results
+    tree = ET.parse(xml_path)
+    for tc in tree.iter("testcase"):
+        cls = tc.get("classname", "").split(".")[-1]
+        name = tc.get("name", "")
+        # pytest encodes the parametrization in name like 'test_x[uniform]';
+        # keep the base method name for matching.
+        base = name.split("[")[0]
+        skipped = tc.find("skipped")
+        if tc.find("failure") is not None or tc.find("error") is not None:
+            status = "fail"
+        elif skipped is not None:
+            kind = (skipped.get("type", "") + " " + skipped.get("message", "")).lower()
+            status = "xfail" if "xfail" in kind else "skip"
+        else:
+            status = "pass"
+        # xpass (strict xfail that passed) surfaces as a failure in JUnit, so
+        # it is already caught above.
+        results[(cls, base)] = status
+    return results
+
+
+def resolve(entry: dict, junit: dict) -> str:
+    """Resolve a manifest entry to a live status token."""
+    declared = entry.get("status", "pending")
+    if declared in ("pending", "notebook"):
+        return declared
+    # "covered" is the manifest's word for "expected to pass"; the render/count
+    # token for a pass is "pass".
+    fallback = "pass" if declared == "covered" else declared
+    ref = entry.get("test")
+    if not ref:
+        return fallback
+    cls, _, method = ref.partition("::")
+    matches = [
+        st
+        for (c, m), st in junit.items()
+        if c == cls and (not method or m == method)
+    ]
+    if not matches:
+        # No live result (suite not run / test missing) -> fall back to intent.
+        return fallback
+    if any(st == "fail" for st in matches):
+        return "fail"
+    if all(st == "xfail" for st in matches):
+        return "xfail"
+    if any(st == "pass" for st in matches):
+        return "pass"
+    if any(st == "skip" for st in matches):
+        return "skip"
+    return matches[0]
+
+
+def summarise(standard: dict, junit: dict) -> dict:
+    rows = []
+    counts = {"pass": 0, "fail": 0, "xfail": 0, "skip": 0, "pending": 0, "notebook": 0}
+    for t in standard["tests"]:
+        st = resolve(t, junit)
+        counts[st] = counts.get(st, 0) + 1
+        rows.append((t, st))
+    # Denominator is the number of rows we track (each row is one test/variant),
+    # so the coverage bar always sums to exactly 100%.
+    total = len(standard["tests"])
+    # "covered" = a live pass, or a demonstrated notebook row.
+    covered = counts["pass"] + counts["notebook"]
+    return {"rows": rows, "counts": counts, "total": total, "covered": covered}
+
+
+# --------------------------------------------------------------------------- #
+# Markdown (pinned issue #67)
+# --------------------------------------------------------------------------- #
+
+MD_ICON = {
+    "pass": ":white_check_mark:",
+    "fail": ":x:",
+    "xfail": ":warning:",
+    "skip": ":fast_forward:",
+    "pending": ":hourglass_flowing_sand:",
+    "notebook": ":ledger:",
+}
+
+
+def render_markdown(data: list, stamp: str) -> str:
+    out = ["## V&V Standards Coverage\n", f"*Last updated: {stamp}*\n"]
+    for std, s in data:
+        out.append(f"### {std['name']} — {s['covered']}/{s['total']} covered")
+        out.append("")
+        out.append("| Test | Criterion | Status |")
+        out.append("|------|-----------|--------|")
+        for t, st in s["rows"]:
+            label = STATUS_META[st][0]
+            out.append(
+                f"| {t['id']} {t['name']} | {t.get('criterion', '')} | {MD_ICON[st]} {label} |"
+            )
+        out.append("")
+    # legend
+    out.append(
+        "Legend: :white_check_mark: pass · :warning: xfail (known model limitation) · "
+        ":ledger: notebook-demonstrated · :fast_forward: skip (placeholder) · "
+        ":hourglass_flowing_sand: pending (not implemented) · :x: fail\n"
+    )
+    return "\n".join(out)
+
+
+# --------------------------------------------------------------------------- #
+# HTML (GitHub Pages dashboard)
+# --------------------------------------------------------------------------- #
+
+CSS = """
+:root{--bg:#fff;--fg:#1b1f24;--muted:#6a737d;--card:#f6f8fa;--border:#d0d7de;
+--pass:#1a7f37;--fail:#cf222e;--xfail:#9a6700;--skip:#6a737d;--pending:#8250df;--notebook:#0969da}
+@media(prefers-color-scheme:dark){:root{--bg:#0d1117;--fg:#e6edf3;--muted:#8b949e;
+--card:#161b22;--border:#30363d;--pass:#3fb950;--fail:#f85149;--xfail:#d29922;--skip:#8b949e;--pending:#a371f7;--notebook:#58a6ff}}
+:root[data-theme=light]{--bg:#fff;--fg:#1b1f24;--muted:#6a737d;--card:#f6f8fa;--border:#d0d7de;
+--pass:#1a7f37;--fail:#cf222e;--xfail:#9a6700;--skip:#6a737d;--pending:#8250df;--notebook:#0969da}
+:root[data-theme=dark]{--bg:#0d1117;--fg:#e6edf3;--muted:#8b949e;--card:#161b22;--border:#30363d;
+--pass:#3fb950;--fail:#f85149;--xfail:#d29922;--skip:#8b949e;--pending:#a371f7;--notebook:#58a6ff}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);
+font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif}
+.wrap{max-width:1040px;margin:0 auto;padding:2rem 1.25rem 4rem}
+h1{font-size:1.6rem;margin:0 0 .25rem}.sub{color:var(--muted);margin:0 0 1.5rem}
+.overall{display:flex;flex-wrap:wrap;gap:.75rem;margin:0 0 2rem}
+.stat{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:.6rem 1rem;min-width:96px}
+.stat b{display:block;font-size:1.5rem;line-height:1.2}.stat span{color:var(--muted);font-size:.8rem}
+.card{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:1.1rem 1.25rem;margin:0 0 1.25rem}
+.card h2{font-size:1.15rem;margin:0}.card .full{color:var(--muted);font-size:.82rem;margin:.15rem 0 .8rem;font-weight:400}
+.bar{display:flex;height:10px;border-radius:6px;overflow:hidden;margin:.2rem 0 .9rem;background:var(--border)}
+.bar i{display:block}.bar .pass{background:var(--pass)}.bar .notebook{background:var(--notebook)}
+.bar .xfail{background:var(--xfail)}.bar .skip{background:var(--skip)}.bar .pending{background:var(--pending)}.bar .fail{background:var(--fail)}
+table{width:100%;border-collapse:collapse;font-size:.9rem}
+th,td{text-align:left;padding:.42rem .5rem;border-bottom:1px solid var(--border);vertical-align:top}
+th{color:var(--muted);font-weight:600;font-size:.78rem;text-transform:uppercase;letter-spacing:.03em}
+td.id{white-space:nowrap;color:var(--muted);font-variant-numeric:tabular-nums}
+.badge{display:inline-block;padding:.08rem .5rem;border-radius:999px;font-size:.72rem;font-weight:700;
+letter-spacing:.02em;color:#fff;white-space:nowrap}
+.badge.pass{background:var(--pass)}.badge.fail{background:var(--fail)}.badge.xfail{background:var(--xfail)}
+.badge.skip{background:var(--skip)}.badge.pending{background:var(--pending)}.badge.notebook{background:var(--notebook)}
+.legend{color:var(--muted);font-size:.82rem;margin-top:1.5rem;line-height:1.9}
+.legend .badge{margin-right:.25rem}
+.tablewrap{overflow-x:auto}a{color:var(--notebook)}
+"""
+
+
+def bar_segments(counts: dict, total: int) -> str:
+    segs = []
+    order = ["pass", "notebook", "xfail", "skip", "fail", "pending"]
+    # pending fills the remainder up to total_defined
+    accounted = sum(counts.get(k, 0) for k in order if k != "pending")
+    counts = dict(counts)
+    counts["pending"] = max(counts.get("pending", 0), total - accounted)
+    for k in order:
+        n = counts.get(k, 0)
+        if n:
+            pct = 100 * n / total if total else 0
+            segs.append(f'<i class="{k}" style="width:{pct:.4f}%"></i>')
+    return "".join(segs)
+
+
+def render_html(data: list, stamp: str) -> str:
+    totals = {"pass": 0, "fail": 0, "xfail": 0, "skip": 0, "pending": 0, "notebook": 0}
+    for _std, s in data:
+        for k in totals:
+            totals[k] += s["counts"].get(k, 0)
+
+    parts = [
+        "<!doctype html><html lang=en><head><meta charset=utf-8>",
+        '<meta name=viewport content="width=device-width,initial-scale=1">',
+        "<title>V&amp;V Standards Coverage — JuPedSim Web Community</title>",
+        f"<style>{CSS}</style></head><body><div class=wrap>",
+        "<h1>V&amp;V Standards Coverage</h1>",
+        f'<p class=sub>Verification &amp; validation across IMO, RiMEA, NIST TN 1822 and ISO 20414. '
+        f'Generated {html.escape(stamp)} from <code>standards/coverage.json</code> + the latest '
+        f'<a href="{REPO}/actions/workflows/vv.yml">V&amp;V run</a>.</p>',
+    ]
+    # overall stat tiles
+    parts.append("<div class=overall>")
+    for key, lbl in [
+        ("pass", "Pass"),
+        ("notebook", "Notebook"),
+        ("xfail", "XFail"),
+        ("skip", "Skip"),
+        ("pending", "Pending"),
+        ("fail", "Fail"),
+    ]:
+        parts.append(f'<div class=stat><b>{totals[key]}</b><span>{lbl}</span></div>')
+    parts.append("</div>")
+
+    for std, s in data:
+        parts.append("<section class=card>")
+        parts.append(
+            f'<h2>{html.escape(std["name"])} '
+            f'<span style="color:var(--muted);font-weight:400;font-size:.9rem">— '
+            f'{s["covered"]}/{s["total"]} covered</span></h2>'
+        )
+        vlabel = "pytest-asserted" if std["verification"] == "pytest" else "notebook-demonstrated"
+        parts.append(f'<p class=full>{html.escape(std["full_name"])} · {vlabel}</p>')
+        parts.append(f'<div class=bar>{bar_segments(s["counts"], s["total"])}</div>')
+        parts.append('<div class=tablewrap><table><thead><tr>'
+                     "<th>Test</th><th>Name</th><th>Criterion</th><th>Status</th>"
+                     "</tr></thead><tbody>")
+        for t, st in s["rows"]:
+            label, cls = STATUS_META[st]
+            name = html.escape(t["name"])
+            if t.get("notebook"):
+                name = f'<a href="{REPO}/blob/main/{t["notebook"]}">{name}</a>'
+            note = t.get("note", "")
+            crit = html.escape(t.get("criterion", ""))
+            if note:
+                crit += f'<br><span style="color:var(--muted);font-size:.82rem">{html.escape(note)}</span>'
+            parts.append(
+                f'<tr><td class=id>{html.escape(t["id"])}</td><td>{name}</td>'
+                f"<td>{crit}</td><td><span class=\"badge {cls}\">{label}</span></td></tr>"
+            )
+        parts.append("</tbody></table></div></section>")
+
+    parts.append(
+        '<p class=legend>'
+        '<span class="badge pass">PASS</span> criterion asserted &amp; met · '
+        '<span class="badge xfail">XFAIL</span> criterion asserted but blocked by a model limitation · '
+        '<span class="badge notebook">NOTEBOOK</span> demonstrated in a notebook (no automated assert) · '
+        '<span class="badge skip">SKIP</span> placeholder test · '
+        '<span class="badge pending">PENDING</span> defined by the standard, not implemented · '
+        '<span class="badge fail">FAIL</span> asserted &amp; failing'
+        "</p>")
+    parts.append("</div></body></html>")
+    return "".join(parts)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manifest", default="standards/coverage.json")
+    ap.add_argument("--junit", default="results/vv-tests.xml")
+    ap.add_argument("--outdir", default="site")
+    args = ap.parse_args()
+
+    manifest = json.loads(pathlib.Path(args.manifest).read_text())
+    junit = parse_junit(pathlib.Path(args.junit))
+    data = [(std, summarise(std, junit)) for std in manifest["standards"]]
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    outdir = pathlib.Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+    (outdir / "index.html").write_text(render_html(data, stamp), encoding="utf-8")
+    (outdir / "summary.md").write_text(render_markdown(data, stamp), encoding="utf-8")
+    print(f"wrote {outdir/'index.html'} and {outdir/'summary.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/standards/coverage.json
+++ b/standards/coverage.json
@@ -1,0 +1,102 @@
+{
+  "_comment": "Single source of truth for V&V standards coverage. Consumed by tests/vv/test_registry.py (CI status table + pinned issue #67) and scripts/gen_standards_report.py (GitHub Pages dashboard). Each test's declared status is the INTENT; for pytest-backed rows the live JUnit result overrides it. status: covered | xfail | skip | pending | notebook. 'test' joins to a pytest testcase by 'ClassPrefix' or 'ClassPrefix::method_name'.",
+  "standards": [
+    {
+      "id": "imo",
+      "name": "IMO MSC.1/Circ.1533",
+      "full_name": "Revised Guidelines for Evacuation Analysis for New and Existing Passenger Ships",
+      "verification": "pytest",
+      "tests": [
+        {"id": "IMO 1", "name": "Walking speed in a corridor", "criterion": "Evacuation time ~ d/v +/- 20%", "status": "covered", "test": "TestSA01"},
+        {"id": "IMO 2", "name": "Walking speed up stairs", "criterion": "Maintain assigned speed upstairs", "status": "pending", "note": "Not implemented as an IMO-tier test; stair speed is covered by RiMEA-02 / NIST-2.2."},
+        {"id": "IMO 3", "name": "Walking speed down stairs", "criterion": "Maintain assigned speed downstairs", "status": "pending", "note": "Not implemented as an IMO-tier test; covered by RiMEA-03 / NIST-2.2."},
+        {"id": "IMO 4", "name": "Exit flow rate", "criterion": "Flow through a 1 m exit is physically plausible", "status": "covered", "test": "TestRE01"},
+        {"id": "IMO 5", "name": "Response time", "criterion": "Agents respect an assigned pre-movement distribution", "status": "pending", "note": "Covered by RiMEA-05 / NIST-1.1; no IMO-tier test."},
+        {"id": "IMO 6", "name": "Rounding corners", "criterion": "Navigate a 90-degree corner, stay in geometry", "status": "covered", "test": "TestSA04"},
+        {"id": "IMO 7", "name": "Assignment of population demographics", "criterion": "All agents evacuate within [25 s, 120 s]", "status": "covered", "test": "TestSA02"},
+        {"id": "IMO 8", "name": "Counterflow", "criterion": "Counterflow increases evacuation time", "status": "covered", "test": "TestRE04"},
+        {"id": "IMO 9", "name": "Exit-count sensitivity", "criterion": "Halving the exits increases evacuation time", "status": "covered", "test": "TestRE02"},
+        {"id": "IMO 10", "name": "Exit route allocation", "criterion": "Agents use assigned escape routes", "status": "pending", "note": "RE-03 is declared in test_imo_room_evacuation.py but not implemented; route allocation is covered by RiMEA-10 / NIST-3.1."},
+        {"id": "IMO 11", "name": "Congestion / flow on stairs", "criterion": "Congestion forms at flow constraints", "status": "pending", "note": "Covered by RiMEA-16 / NIST-5.1; no IMO-tier test."}
+      ]
+    },
+    {
+      "id": "rimea",
+      "name": "RiMEA 4.1.1",
+      "full_name": "Guideline for Microscopic Evacuation Analysis (RiMEA), section 4.1.1 verification tests",
+      "verification": "pytest",
+      "tests": [
+        {"id": "Test 1", "name": "Speed in a corridor", "criterion": "Travel time at 1.33 m/s in [26, 34] s", "status": "covered", "test": "TestRiMEA01"},
+        {"id": "Test 2", "name": "Speed up stairs", "criterion": "Walking speed maintained upstairs", "status": "covered", "test": "TestRiMEA02"},
+        {"id": "Test 3", "name": "Speed down stairs", "criterion": "Walking speed maintained downstairs", "status": "covered", "test": "TestRiMEA03"},
+        {"id": "Test 4", "name": "Fundamental diagram", "criterion": "Speed-density relation matches empirical data", "status": "skip", "note": "Placeholder: requires measurement areas + density sweeps."},
+        {"id": "Test 5", "name": "Pre-movement time", "criterion": "Agents respect assigned pre-movement delay", "status": "covered", "test": "TestRiMEA05"},
+        {"id": "Test 6", "name": "Corner movement", "criterion": "Navigate a corner without wall penetration", "status": "covered", "test": "TestRiMEA06"},
+        {"id": "Test 7", "name": "Demographic parameters", "criterion": "Speed distribution matches the age-based table", "status": "covered", "test": "TestRiMEA07"},
+        {"id": "Test 8", "name": "Parameter study", "criterion": "Evacuation time varies with parameters", "status": "skip", "note": "Placeholder: requires a parameter sweep harness."},
+        {"id": "Test 9", "name": "Large public space", "criterion": "Closing 2/4 exits increases evacuation time", "status": "covered", "test": "TestRiMEA09"},
+        {"id": "Test 10", "name": "Route allocation", "criterion": "Agents use assigned escape routes", "status": "covered", "test": "TestRiMEA10"},
+        {"id": "Test 11", "name": "Escape route choice", "criterion": "Agents prefer the closer exit", "status": "skip", "note": "Placeholder: requires route-choice modeling."},
+        {"id": "Test 12a", "name": "Goal position", "criterion": "Closer goal yields shorter evacuation", "status": "covered", "test": "TestRiMEA12a"},
+        {"id": "Test 12b", "name": "Bottleneck length", "criterion": "Longer bottleneck increases evacuation time", "status": "covered", "test": "TestRiMEA12b"},
+        {"id": "Test 12c", "name": "Congestion influence", "criterion": "Measure congestion influence at bottlenecks", "status": "covered", "test": "TestRiMEA12c"},
+        {"id": "Test 12d", "name": "Bottleneck width", "criterion": "Wider bottleneck yields faster evacuation", "status": "covered", "test": "TestRiMEA12d"},
+        {"id": "Test 13", "name": "Fundamental diagram on stairs", "criterion": "Down-stair speed > up-stair speed", "status": "covered", "test": "TestRiMEA13"},
+        {"id": "Test 14", "name": "Route choice", "criterion": "Document short vs long route preference", "status": "covered", "test": "TestRiMEA14"},
+        {"id": "Test 15", "name": "Large crowd around a corner", "criterion": "Corner slows evacuation vs a straight path", "status": "covered", "test": "TestRiMEA15"},
+        {"id": "Test 16", "name": "1D fundamental diagram", "criterion": "1D speed-density within the empirical envelope", "status": "covered", "test": "TestRiMEA16"}
+      ]
+    },
+    {
+      "id": "nist",
+      "name": "NIST TN 1822",
+      "full_name": "The Process of Verification and Validation of Building Fire Evacuation Models (Ronchi et al., 2013)",
+      "verification": "pytest",
+      "tests": [
+        {"id": "Verif.1.1", "name": "Pre-evacuation time distributions", "criterion": "KS p > 0.05 for uniform/gamma/lognormal/weibull", "status": "covered", "test": "TestNist11Premovement"},
+        {"id": "Verif.2.1", "name": "Speed in a corridor", "criterion": "Walking speed 1.0 +/- 0.05 m/s over the 40 m segment", "status": "covered", "test": "TestNist21CorridorSpeed"},
+        {"id": "Verif.2.2", "name": "Speed on stairs (up)", "criterion": "Stair speed 1.0 +/- 0.05 m/s upward over 100 m", "status": "covered", "test": "TestNist22StairsUp"},
+        {"id": "Verif.2.2", "name": "Speed on stairs (down)", "criterion": "Stair speed 1.0 +/- 0.05 m/s downward over 100 m", "status": "covered", "test": "TestNist22StairsDown"},
+        {"id": "Verif.2.3", "name": "Movement around a corner", "criterion": "All 20 agents evacuate; no boundary penetration", "status": "covered", "test": "TestNist23Corner"},
+        {"id": "Verif.2.4", "name": "Assigned demographics", "criterion": "Gaussian(1.2, 0.2) desired-speed distribution configured", "status": "covered", "test": "TestNist24Demographics"},
+        {"id": "Verif.2.5", "name": "Reduced visibility vs walking speed", "criterion": "Smoke-driven speed reduction", "status": "pending", "note": "Needs smoke / extinction-coefficient handling."},
+        {"id": "Verif.2.6", "name": "Agent incapacitation (FED)", "criterion": "FED-driven incapacitation", "status": "pending", "note": "Needs an FED sub-model."},
+        {"id": "Verif.2.7", "name": "Elevator usage", "criterion": "Agents evacuate via elevator", "status": "pending", "note": "Needs an elevator component."},
+        {"id": "Verif.2.8", "name": "Horizontal counter-flows", "criterion": "Primary completions non-increasing as counterflow grows (equal budget)", "status": "covered", "test": "TestNist28Counterflow"},
+        {"id": "Verif.2.9", "name": "Group behaviours", "criterion": "Group 1 arrival spread <= 10 s", "status": "xfail", "test": "TestNist29Groups::test_group1_arrives_together", "note": "CollisionFreeSpeedModel has no group-cohesion model (spread ~24 s)."},
+        {"id": "Verif.2.10", "name": "Agents with movement disabilities", "criterion": "Reduced-mobility agent profiles", "status": "pending", "note": "Needs reduced-mobility / agent-size profiles."},
+        {"id": "Verif.3.1", "name": "Exit route allocation", "criterion": "Each of 13 agents reaches its allocated exit", "status": "covered", "test": "TestNist31RouteAllocation"},
+        {"id": "Verif.3.2", "name": "Social influence", "criterion": "Exit choice shifts under social influence", "status": "pending", "note": "Needs a social-influence component."},
+        {"id": "Verif.3.3", "name": "Affiliation", "criterion": "Agents prefer familiar exits", "status": "pending", "note": "Needs an affiliation component."},
+        {"id": "Verif.4.1", "name": "Dynamic availability of exits", "criterion": "Agents reroute when an exit closes at runtime", "status": "pending", "note": "Needs runtime exit toggling."},
+        {"id": "Verif.5.1", "name": "Congestion", "criterion": "Peak density at the room exit > corridor midsection", "status": "covered", "test": "TestNist51Congestion"},
+        {"id": "Verif.5.2", "name": "Maximum flow rates", "criterion": "Sustained specific flow <= 1.33 p/m/s (IMO)", "status": "xfail", "test": "TestNist52MaxFlow", "note": "CollisionFreeSpeedModel has no door-flow limiter (emergent ~5 p/m/s)."}
+      ]
+    },
+    {
+      "id": "iso",
+      "name": "ISO 20414:2020",
+      "full_name": "Fire safety engineering - Verification and validation protocol for building fire evacuation models",
+      "verification": "notebook",
+      "tests": [
+        {"id": "Test 1", "name": "Pre-evacuation time assignment", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso01_premovement.ipynb"},
+        {"id": "Test 2", "name": "Walking speed in a corridor", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso02_corridor_speed.ipynb"},
+        {"id": "Test 3", "name": "Walking speed on stairs", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso03_stairs.ipynb"},
+        {"id": "Test 4", "name": "Movement around a corner", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso04_corner.ipynb"},
+        {"id": "Test 5", "name": "Assigned occupant demographics", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso05_demographics.ipynb"},
+        {"id": "Test 6", "name": "Horizontal counter-flows", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso06_counterflow.ipynb"},
+        {"id": "Test 7", "name": "Occupant incapacitation", "criterion": "FED-driven incapacitation", "status": "pending", "note": "Not shipped; needs an FED sub-model."},
+        {"id": "Test 8", "name": "Exit route allocation", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso08_route_allocation.ipynb"},
+        {"id": "Test 9", "name": "Elevator usage", "criterion": "Agents evacuate via elevator", "status": "pending", "note": "Not shipped; needs an elevator component."},
+        {"id": "Test 10", "name": "Congestion in front of a stair", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso10_congestion.ipynb"},
+        {"id": "Test 11", "name": "Maximum flow rates at an exit", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso11_max_flow.ipynb"},
+        {"id": "Test 12", "name": "Stair flow rates", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso12_stair_flow.ipynb"},
+        {"id": "Test 13", "name": "Flow, density and speed in a corridor", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso13_corridor_fd.ipynb"},
+        {"id": "Test 14", "name": "Group behaviour", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso14_group_behaviour.ipynb"},
+        {"id": "Test 15", "name": "Social influence on exit choice", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso15_social_influence.ipynb"},
+        {"id": "Test 16", "name": "Affiliation to familiar exits", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso16_familiar_exits.ipynb"},
+        {"id": "Test 17", "name": "Route choice from geometric layout", "criterion": "Demonstrated in notebook", "status": "notebook", "notebook": "standards/iso/iso17_route_choice.ipynb"}
+      ]
+    }
+  ]
+}

--- a/tests/vv/test_registry.py
+++ b/tests/vv/test_registry.py
@@ -1,52 +1,29 @@
-"""V&V test registry — single source of truth for test metadata.
+"""V&V test registry — derived view over the standards coverage manifest.
 
-Maps test class prefixes to (human-readable name, reference, criterion).
-Used by CI summary script and available for future test tooling.
-
-To add ISO/RiMEA tests, append entries here.
+The single source of truth is ``standards/coverage.json``. This module exposes
+``TEST_MAP`` (a ``{pytest-class-prefix: (name, reference, criterion)}`` dict)
+for tooling that wants to join pytest results to standard metadata. To change a
+criterion or add a test, edit the manifest, not this file.
 """
 
-TEST_MAP = {
-    # IMO-inspired tests
-    "TestSA01": ("SA-01 Speed in Corridor", "IMO 1", "Evacuation time ~ d/v +/- 20%"),
-    "TestSA02": ("SA-02 Speed Distribution", "IMO 7", "All evacuate in [25s, 120s]"),
-    "TestSA04": ("SA-04 Cornering", "IMO 6", "Navigate 90-deg corner, stay in geometry"),
-    "TestRE01": ("RE-01 Single Exit Flow", "IMO 4", "Flow rate through 1m exit physically plausible"),
-    "TestRE02": ("RE-02 Exit Sensitivity", "IMO 9", "Halving exits increases evacuation time"),
-    "TestRE04": ("RE-04 Counterflow", "IMO 8", "Counterflow increases evacuation time"),
-    # Behavior/property tests
-    "TestBP02": ("BP-02 Bounds Check", "\u2014", "Agents stay within walkable area bounds"),
-    "TestBP04": ("BP-04 Full Evacuation", "\u2014", "All agents evacuate within max time"),
-    # RiMEA 4.1.1 tests
-    "TestRiMEA01": ("RiMEA-01 Speed in Corridor", "RiMEA 4.1.1 Test 1", "Travel time at 1.33 m/s in [26, 34]s"),
-    "TestRiMEA02": ("RiMEA-02 Speed Up Stairs", "RiMEA 4.1.1 Test 2", "Walking speed maintained on stairs (up)"),
-    "TestRiMEA03": ("RiMEA-03 Speed Down Stairs", "RiMEA 4.1.1 Test 3", "Walking speed maintained on stairs (down)"),
-    "TestRiMEA04": ("RiMEA-04 Fundamental Diagram", "RiMEA 4.1.1 Test 4", "Speed-density relation matches empirical data"),
-    "TestRiMEA05": ("RiMEA-05 Premovement Time", "RiMEA 4.1.1 Test 5", "Agents respect assigned premovement delay"),
-    "TestRiMEA06": ("RiMEA-06 Corner Movement", "RiMEA 4.1.1 Test 6", "Agents navigate corner without wall penetration"),
-    "TestRiMEA07": ("RiMEA-07 Demographic Params", "RiMEA 4.1.1 Test 7", "Speed distribution matches age-based table"),
-    "TestRiMEA08": ("RiMEA-08 Parameter Study", "RiMEA 4.1.1 Test 8", "Evacuation time varies with parameters"),
-    "TestRiMEA09": ("RiMEA-09 Large Public Space", "RiMEA 4.1.1 Test 9", "Closing 2/4 exits increases evacuation time"),
-    "TestRiMEA10": ("RiMEA-10 Route Allocation", "RiMEA 4.1.1 Test 10", "Agents use assigned escape routes"),
-    "TestRiMEA11": ("RiMEA-11 Escape Route Choice", "RiMEA 4.1.1 Test 11", "Agents prefer closer exit"),
-    "TestRiMEA12a": ("RiMEA-12a Goal Position", "RiMEA 4.1.1 Test 12a", "Closer goal yields shorter evacuation"),
-    "TestRiMEA12b": ("RiMEA-12b Bottleneck Length", "RiMEA 4.1.1 Test 12b", "Longer bottleneck increases evacuation time"),
-    "TestRiMEA12c": ("RiMEA-12c Congestion", "RiMEA 4.1.1 Test 12c", "Measure congestion influence at bottlenecks"),
-    "TestRiMEA12d": ("RiMEA-12d Bottleneck Width", "RiMEA 4.1.1 Test 12d", "Wider bottleneck yields faster evacuation"),
-    "TestRiMEA13": ("RiMEA-13 FD Stairs", "RiMEA 4.1.1 Test 13", "Down-stair speed > up-stair speed"),
-    "TestRiMEA14": ("RiMEA-14 Route Choice", "RiMEA 4.1.1 Test 14", "Document short vs long route preference"),
-    "TestRiMEA15": ("RiMEA-15 Large Crowd Corner", "RiMEA 4.1.1 Test 15", "Corner slows evacuation vs straight path"),
-    "TestRiMEA16": ("RiMEA-16 1D Fund. Diagram", "RiMEA 4.1.1 Test 16", "1D speed-density within empirical envelope"),
-    # NIST TN 1822 tests
-    "TestNist11Premovement": ("NIST-1.1 Pre-evacuation Distributions", "NIST TN 1822 Verif.1.1", "KS p > 0.05 for uniform/gamma/lognormal/weibull"),
-    "TestNist21CorridorSpeed": ("NIST-2.1 Corridor Speed", "NIST TN 1822 Verif.2.1", "Walking speed within 1.0 +/- 0.05 m/s over 40 m segment"),
-    "TestNist22StairsUp": ("NIST-2.2 Stairs Up", "NIST TN 1822 Verif.2.2", "Stair speed within 1.0 +/- 0.05 m/s upward over 100 m segment"),
-    "TestNist22StairsDown": ("NIST-2.2 Stairs Down", "NIST TN 1822 Verif.2.2", "Stair speed within 1.0 +/- 0.05 m/s downward over 100 m segment"),
-    "TestNist23Corner": ("NIST-2.3 Corner", "NIST TN 1822 Verif.2.3", "All 20 agents evacuate; no boundary penetration"),
-    "TestNist24Demographics": ("NIST-2.4 Demographics", "NIST TN 1822 Verif.2.4", "Gaussian(1.2, 0.2) desired-speed distribution configured"),
-    "TestNist28Counterflow": ("NIST-2.8 Counterflow", "NIST TN 1822 Verif.2.8", "Primary evacuated count non-increasing in counterflow population"),
-    "TestNist29Groups": ("NIST-2.9 Groups", "NIST TN 1822 Verif.2.9", "Scenario loads and runs (native group cohesion absent)"),
-    "TestNist31RouteAllocation": ("NIST-3.1 Route Allocation", "NIST TN 1822 Verif.3.1", "Each of 23 agents reaches the exit allocated by its journey"),
-    "TestNist51Congestion": ("NIST-5.1 Congestion", "NIST TN 1822 Verif.5.1", "Peak density at room exit > peak density in corridor"),
-    "TestNist52MaxFlow": ("NIST-5.2 Max Flow", "NIST TN 1822 Verif.5.2", "Mode B: emergent flow finite and positive (1.33 p/m/s informational)"),
-}
+import json
+import pathlib
+
+_MANIFEST = pathlib.Path(__file__).resolve().parents[2] / "standards" / "coverage.json"
+
+
+def _build_map() -> dict:
+    data = json.loads(_MANIFEST.read_text())
+    mapping = {}
+    for std in data["standards"]:
+        for t in std["tests"]:
+            ref = t.get("test")
+            if not ref:
+                continue
+            cls = ref.split("::")[0]
+            name = f"{t['id']} {t['name']}"
+            mapping[cls] = (name, std["name"], t.get("criterion", ""))
+    return mapping
+
+
+TEST_MAP = _build_map()


### PR DESCRIPTION
Replaces the flat, drift-prone V&V status table (issue #67) with a **manifest-driven standards coverage report**, published to **GitHub Pages** and mirrored back into #67.

## Why

#67 is auto-refreshed but was semantically stale and incomplete:
- The **entire ISO 20414 suite (17 tests) was missing** — ISO has no pytest tests (notebook-demonstrated), so it never appeared.
- NIST labels drifted (still said "23 agents", "Mode B") because the descriptions came from a hardcoded `test_registry.py` map that wasn't updated with the tests.
- **xfails read as skips** — pytest writes xfail as `<skipped>` in JUnit, so NIST-5.2 showed `SKIP` and NIST-2.9's xfail was hidden. A known model limitation looked like an un-run test.

## What

- **`standards/coverage.json`** — single source of truth. Every test each standard (IMO / RiMEA / NIST TN 1822 / ISO 20414) defines, with declared status, criterion, and the pytest class it maps to. Includes **pending** (defined-but-not-built) and **notebook** (ISO, demonstrated without asserts) rows, so coverage is real — not just "tests that exist".
- **`scripts/gen_standards_report.py`** — stdlib-only generator. Joins the manifest to the live JUnit results and emits a self-contained, theme-aware **HTML dashboard** (per-standard coverage bars + matrices) and a Markdown mirror. Distinguishes **XFAIL vs SKIP**.
- **`tests/vv/test_registry.py`** — now *derives* `TEST_MAP` from the manifest (kills the drift at the root).
- **`.github/workflows/vv.yml`** — from the single test run: generate the report, PATCH #67 with the Markdown, and deploy the HTML to Pages (main only).

## Live result (this run: 49 passed, 3 skipped, 2 xfailed)

Per-standard coverage: **IMO 6/11 · RiMEA 16/19 · NIST 9/18 · ISO 15/17**. NIST-2.9 and NIST-5.2 now correctly render **XFAIL** (model limitation), RiMEA-4/8/11 as **SKIP** (placeholders), ISO as **NOTEBOOK**. Light + dark themes verified via headless render.

## Action required before this helps on `main`

Enable **Settings → Pages → Build and deployment → Source: GitHub Actions**. Until then the `deploy-pages` job will fail on `main` pushes (the tests + #67 mirror still work). Dashboard URL will be `https://pedestriandynamics.github.io/jupedsim-web-community/`.

On PRs the workflow only runs tests + generates the report (no #67 write, no Pages deploy), so this PR's own CI validates the generator end-to-end.